### PR TITLE
feat: implement Agent Skills parsing and global tool registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,27 @@ Or
              (shell-command-to-string (format "ruskel %s </dev/null 2>&1" target))))
 ```
 
+### Agent Skills
+
+`macher-agent` includes support for reading and parsing Agent Skills, loosely based on the [AgentSkills SKILL.md specification](https://agentskills.io/specification/SKILL.md). This system automatically converts folder-based skill structures into `gptel` directives.
+
+A skill is defined by a `SKILL.md` file containing YAML or JSON-like frontmatter with a `name`, `description`, and `allowed-tools` array. The Markdown body is treated as the system prompt instructions.
+
+Example `SKILL.md`:
+```markdown
+---
+name: mock-skillp
+description: A testing skill
+allowed-tools: ["example-tool"]
+---
+You are a testing assistant. Please use the example tool when needed.
+```
+#### Configuration and Security
+*   `macher-agent-global-skills-directory` this custom variable to a trusted directory containing global agent skills. If a tool mentioned in `allowed-tools` is not registered natively, `macher-agent` will attempt to dynamically evaluate and load its implementation script from `<global-directory>/scripts/<tool-name>.el`.
+* `macher-agent` can also load skills from your active Emacs workspace (`M-x macher-agent-load-workspace-skills`). However, to maintain a secure sandbox, *scripts are ignored in workspace skills*. Workspace skills may only use tools that are already globally registered.
+
+When an Agent Skill is selected via `gptel`'s menu ( by selecting its `name`), `macher-agent` intercepts the selection and automatically activates the required tools for that session into `gptel-tools`.
+
 ### Macher context availability
 
 All tools built with `macher-agent-make-tool` (or `gptel-make-tool` after macher-agent has loaded) will have their category added to the evaluation list used by macher (which by default only loads the macher-tool-category). View the current macher-context real time using `macher-agent-context-tree`

--- a/macher-agent-skills.el
+++ b/macher-agent-skills.el
@@ -1,0 +1,129 @@
+;;; macher-agent-skills.el --- Agent Skills parsing and resolution -*- lexical-binding: t -*-
+
+(require 'cl-lib)
+
+(defvar macher-agent-tools-registry (make-hash-table :test 'equal)
+  "Global registry mapping tool names (strings) to gptel tool objects.")
+
+(defvar macher-agent-skills-alist nil
+  "Alist mapping skill name symbols to skill metadata.")
+
+(defun macher-agent--parse-yaml-array (text key)
+  "Extract a YAML list for KEY from TEXT. 
+Handles both inline JSON arrays [...] and YAML block lists (- item)."
+  (let ((items nil))
+    (if (string-match (format "^%s:[ \t]*\\[\\(.*\\)\\]" key) text)
+        ;; Parse inline array format: ["tool_1", "tool_2"]
+        (let ((raw-items (split-string (match-string 1 text) "[, \t\n\r\"]+" t)))
+          (setq items raw-items))
+      ;; Parse block list format:
+      ;; - tool_1
+      ;; - tool_2
+      (let* ((lines (split-string text "\n"))
+             (in-list nil))
+        (dolist (line lines)
+          (cond
+           ((string-match (format "^%s:" key) line)
+            (setq in-list t))
+           ((and in-list (string-match "^[ \t]+-[ \t]+\"?\\([^\"]+\\)\"?" line))
+            (push (match-string 1 line) items))
+           ((and in-list (string-match "^[A-Za-z0-9_-]+:" line))
+            (setq in-list nil))))
+        (setq items (nreverse items))))
+    items))
+
+(defun macher-agent-parse-skill-file (filepath)
+  "Parse a SKILL.md file at FILEPATH extracting frontmatter and body.
+Returns a property list compatible with the tests."
+  (with-temp-buffer
+    (insert-file-contents filepath)
+    (goto-char (point-min))
+    (let ((name nil) (desc nil) (tools nil) (body nil))
+      ;; Extract YAML Frontmatter
+      (when (re-search-forward "^---\n" nil t)
+        (let ((start (point)))
+          (when (re-search-forward "^---\n" nil t)
+            (let ((frontmatter (buffer-substring-no-properties start (match-beginning 0))))
+              (when (string-match "^name:[ \t]*\"?\\([^\n\"]+\\)\"?" frontmatter)
+                (setq name (match-string 1 frontmatter)))
+              (when (string-match "^description:[ \t]*\"?\\([^\n\"]+\\)\"?" frontmatter)
+                (setq desc (match-string 1 frontmatter)))
+              (setq tools (macher-agent--parse-yaml-array frontmatter "allowed-tools"))))))
+      ;; Extract Markdown Body
+      (setq body (string-trim (buffer-substring-no-properties (point) (point-max))))
+      (list :name name
+            :name-sym (when name (intern name))
+            :description desc
+            :allowed-tools tools
+            :body body))))
+
+(defun macher-agent-resolve-tool (tool-name dir-context)
+  "Retrieve TOOL-NAME from registry, or load it from DIR-CONTEXT/scripts if missing."
+  (or (gethash tool-name macher-agent-tools-registry)
+      (when dir-context
+        (let ((script-path (expand-file-name (format "scripts/%s.el" tool-name) dir-context)))
+          (when (file-exists-p script-path)
+            (let ((tool (with-temp-buffer
+                          (insert-file-contents script-path)
+                          (let ((val nil))
+                            (condition-case nil
+                                (while t
+                                  (setq val (eval (read (current-buffer)) lexical-binding)))
+                              (end-of-file val))))))
+              (when tool
+                (puthash tool-name tool macher-agent-tools-registry)))
+            (gethash tool-name macher-agent-tools-registry))))))
+
+(defun macher-agent-load-skill-from-file (filepath &optional is-global)
+  "Load skill from FILEPATH. 
+If IS-GLOBAL is non-nil, sets :context-dir to allow script resolution."
+  (let* ((parsed (macher-agent-parse-skill-file filepath))
+         (name-sym (plist-get parsed :name-sym))
+         (dir-context (if is-global (file-name-directory filepath) nil)))
+    (when name-sym
+      (setf (alist-get name-sym macher-agent-skills-alist)
+            (list :description (plist-get parsed :description)
+                  :tools (plist-get parsed :allowed-tools)
+                  :context-dir dir-context
+                  :body (plist-get parsed :body))))
+    parsed))
+
+(defun macher-agent--apply-skill-tools (preset-sym)
+  "Apply the tools of PRESET-SYM into `gptel-tools`."
+  (let* ((skill-meta (alist-get preset-sym macher-agent-skills-alist))
+         (tool-names (plist-get skill-meta :tools))
+         (dir-context (plist-get skill-meta :context-dir)))
+    (when skill-meta
+      (dolist (tname tool-names)
+        (let ((tool (macher-agent-resolve-tool tname dir-context)))
+          (when tool
+            (add-to-list 'gptel-tools tool)))))))
+
+(defun macher-agent-initialize-skills (&optional dir)
+  "Load all skills from DIR (defaults to `macher-agent-global-skills-directory`).
+This populates `gptel-directives` with the skill bodies and pre-loads scripts
+so they appear in the `gptel-menu`."
+  (interactive)
+  (let ((skills-dir (or dir (bound-and-true-p macher-agent-global-skills-directory))))
+    (when (and skills-dir (file-exists-p skills-dir))
+      ;; 1. Pre-load all scripts so gptel knows about them (for the menu)
+      (let ((scripts-dir (expand-file-name "scripts" skills-dir)))
+        (when (file-directory-p scripts-dir)
+          (dolist (script (directory-files scripts-dir t "\\.el$"))
+            (let* ((base (file-name-base script))
+                   (tool (macher-agent-resolve-tool base skills-dir)))
+              ;; Tool is resolved and cached in registry by resolve-tool
+              (ignore tool)))))
+      
+      ;; 2. Load all SKILL.md files into gptel-directives
+      (dolist (subdir (directory-files skills-dir t "^[^.]"))
+        (when (file-directory-p subdir)
+          (let ((skill-file (expand-file-name "SKILL.md" subdir)))
+            (when (file-exists-p skill-file)
+              (let* ((parsed (macher-agent-load-skill-from-file skill-file t))
+                     (sym (plist-get parsed :name-sym))
+                     (body (plist-get parsed :body)))
+                (when (and sym body)
+                  (setf (alist-get sym gptel-directives) body))))))))))
+
+(provide 'macher-agent-skills)

--- a/macher-agent.el
+++ b/macher-agent.el
@@ -1,7 +1,7 @@
 ;;; macher-agent.el --- Sandboxed, Language-Agnostic AI Workflows -*- lexical-binding: t; -*-
 
 ;; Author: Elijah Charles
-;; Version: 0.0.11
+;; Version: 0.1.0
 ;; Package-Requires: ((emacs "29.1") (gptel "0.9.0") (macher "0.5.0"))
 ;; Keywords: convenience, gptel, llm, macher
 ;; URL: https://github.com/elij/macher-agent
@@ -17,6 +17,7 @@
 (require 'macher-agent-orchestration)
 (require 'macher-agent-context-tools)
 (require 'macher-agent-gptel-tools)
+(require 'macher-agent-skills)
 
 (defgroup macher-agent nil
   "Agent tools within the macher edit context ."
@@ -25,6 +26,16 @@
 
 (defvar macher-agent-active-subagents nil
   "Alist of active sub-agents and their locked directories.")
+
+(defcustom macher-agent-global-skills-directory nil
+  "Directory containing global agent skills."
+  :type 'directory
+  :group 'macher-agent)
+
+;; Initialize skills when loaded, if configured
+(with-eval-after-load 'macher-agent
+  (when macher-agent-global-skills-directory
+    (macher-agent-initialize-skills)))
 
 (provide 'macher-agent)
 ;;; macher-agent.el ends here

--- a/tests/fixtures/skills/global/SKILL.md
+++ b/tests/fixtures/skills/global/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: mock-skill
+description: A mock skill for testing
+allowed-tools: ["mock-tool-1", "mock-tool-2"]
+---
+This is the system prompt for the mock skill.
+It spans multiple lines.

--- a/tests/fixtures/skills/workspace/SKILL.md
+++ b/tests/fixtures/skills/workspace/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: workspace-skill
+description: A workspace skill
+allowed-tools: ["workspace-tool-1"]
+---
+Workspace skill body.

--- a/tests/macher-agent-test.el
+++ b/tests/macher-agent-test.el
@@ -8,6 +8,7 @@
 (require 'macher-agent-context-tools)
 (require 'macher-agent-gptel-tools)
 (require 'macher-agent-orchestration)
+(require 'macher-agent-skills)
 
 (cl-defstruct mock-fsm info)
 
@@ -334,6 +335,60 @@
                                (arity (func-arity tool-fn)))
                           (expect (car arity) :to-equal 1)
                           (expect (cdr arity) :to-equal 1))))
-          )
+          
+          (describe "Agent Skills (macher-agent-skills.el)"
+                    (it "parses SKILL.md files correctly extracting frontmatter and markdown body"
+                        (let* ((parsed (macher-agent-parse-skill-file "tests/fixtures/skills/global/SKILL.md")))
+                          (expect (plist-get parsed :name) :to-equal "mock-skill")
+                          (expect (plist-get parsed :name-sym) :to-equal 'mock-skill)
+                          (expect (plist-get parsed :description) :to-equal "A mock skill for testing")
+                          (expect (plist-get parsed :allowed-tools) :to-equal '("mock-tool-1" "mock-tool-2"))
+                          (expect (plist-get parsed :body) :to-equal "This is the system prompt for the mock skill.\nIt spans multiple lines.")))
+
+                    (it "resolves global skill tools by loading their script if not registered"
+                        (let* ((mock-script-dir "tests/fixtures/skills/global/scripts")
+                               (mock-script-path (expand-file-name "mock-tool-load.el" mock-script-dir)))
+                          ;; Setup mock script
+                          (make-directory mock-script-dir t)
+                          (with-temp-file mock-script-path
+                            (insert "(setq mock-tool-load 'loaded-tool-object)"))
+                          
+                          ;; Resolution test
+                          (let ((resolved (macher-agent-resolve-tool "mock-tool-load" "tests/fixtures/skills/global/")))
+                            (expect resolved :to-equal 'loaded-tool-object))
+                          
+                          (delete-directory mock-script-dir t)))
+
+                    (it "refuses to load workspace skill tools (security context)"
+                        (let* ((mock-script-dir "tests/fixtures/skills/workspace/scripts")
+                               (mock-script-path (expand-file-name "workspace-tool-1.el" mock-script-dir)))
+                          ;; Setup mock script
+                          (make-directory mock-script-dir t)
+                          (with-temp-file mock-script-path
+                            (insert "(setq workspace-tool-1 'workspace-loaded)"))
+                          
+                          ;; Test workspace parsing logic
+                          (macher-agent-load-skill-from-file "tests/fixtures/skills/workspace/SKILL.md" nil)
+                          (let ((skill-meta (alist-get 'workspace-skill macher-agent-skills-alist)))
+                            (expect (plist-get skill-meta :context-dir) :to-be nil))
+                          
+                          ;; Resolution should fail to load because context-dir is nil
+                          (let ((resolved (macher-agent-resolve-tool "workspace-tool-1" nil)))
+                            (expect resolved :to-be nil)
+                            (expect (boundp 'workspace-tool-1) :to-be nil))
+                          
+                          (delete-directory mock-script-dir t)))
+                    
+                    (it "applies skill tools correctly into gptel-tools when selected"
+                        (let ((gptel-tools nil)
+                              (mock-tool-obj 'the-tool))
+                          (puthash "selected-tool" mock-tool-obj macher-agent-tools-registry)
+                          
+                          (setf (alist-get 'test-preset macher-agent-skills-alist)
+                                (list :description "test" :tools '("selected-tool") :context-dir nil))
+                          
+                          (macher-agent--apply-skill-tools 'test-preset)
+                          
+                          (expect gptel-tools :to-equal (list mock-tool-obj))))))
 
 (provide 'macher-agent-test)


### PR DESCRIPTION
Add `macher-agent-skills.el` to parse `SKILL.md` files for gptel directives. Extract `name`, `description`, and `allowed-tools` from YAML frontmatter and map markdown body to the system prompt.

Introduce `macher-agent-global-skills-directory` to define a trusted context for global skills. Implement a global registry (`macher-agent-tools-registry`) to evaluate and store tool scripts from `scripts/` directories.

Implement security context logic to prevent automatic evaluation of untrusted workspace scripts.