### PR TITLE
refactor: isolate gptel state and fix delegate execution crashes

### DIFF
--- a/macher-agent-api.el
+++ b/macher-agent-api.el
@@ -33,9 +33,6 @@
 (defvar-local macher-agent-parent-buffer nil
   "Stores the name of the buffer this chat branched from.")
 
-(defvar-local macher-agent--active-skill-sym nil
-  "The active skill symbol for this buffer. Acts as the anchor for FSM composition.")
-
 (defmacro macher-agent-with-project-root (&rest body)
   "Execute BODY with `default-directory` strictly bound to the absolute project root."
   `(let ((default-directory (file-name-as-directory (macher-agent--get-project-root))))
@@ -143,56 +140,64 @@
               :allowed-tools tools
               :body body)))))
 
+(defun macher-agent--evaluate-and-cache-tool (content tool-name registry)
+  "Evaluate string CONTENT and cache it in REGISTRY under TOOL-NAME."
+  (let ((tool (with-temp-buffer
+                (insert content)
+                (goto-char (point-min))
+                (let ((val nil)
+                      (lexical-binding t)
+                      (security-fail (or (re-search-forward "(defun " nil t)
+                                         (re-search-forward "(defvar " nil t))))
+                  (if security-fail
+                      (progn
+                        (message "Macher-Agent SECURITY WARNING: Skipped tool '%s' because it contains defun/defvar. Core overrides forbidden." tool-name)
+                        nil)
+                    (goto-char (point-min))
+                    (condition-case err
+                        (while t
+                          (let ((form (read (current-buffer))))
+                            (setq val (eval form t))))
+                      (end-of-file (if (and (symbolp val) (boundp val))
+                                       (symbol-value val)
+                                     val))
+                      (error
+                       (message "Macher-Agent: Failed to load tool %s - %s" tool-name err)
+                       nil)))))))
+    (when tool
+      (puthash tool-name tool registry))
+    tool))
+
 (defun macher-agent-resolve-tool (tool-name context dir-context)
   "Retrieve TOOL-NAME from workspace registry or load from VFS/disk, deferring native tools."
   (let* ((workspace (when context (macher-agent--get-context-workspace context)))
          (registry (if workspace (macher-agent-workspace-tools-registry workspace) macher-agent-tools-registry))
-         (cached (gethash tool-name registry)))
-    (or cached
-        (let* ((script-paths (delq nil (list
-                                        (when dir-context (expand-file-name (format "scripts/%s.el" tool-name) dir-context))
-                                        (expand-file-name (format "scripts/%s.el" tool-name) macher-agent-bundled-skills-directory))))
-               (content nil))
-          (catch 'found
-            (dolist (path script-paths)
-              (let ((vfs-content (when context (ignore-errors (macher-agent--read-context-file context path)))))
-                (when vfs-content
-                  (setq content vfs-content)
-                  (throw 'found t)))
-              (when (file-exists-p path)
-                (with-temp-buffer
-                  (insert-file-contents path)
-                  (setq content (buffer-string))
-                  (throw 'found t)))))
-          (if content
-              (let ((tool (with-temp-buffer
-                            (insert content)
-                            (goto-char (point-min))
-                            ;; Move the security check so it doesn't hard-crash the loop
-                            (let ((val nil)
-                                  (lexical-binding t)
-                                  (security-fail (or (re-search-forward "(defun " nil t)
-                                                     (re-search-forward "(defvar " nil t))))
-                              (if security-fail
-                                  (progn
-                                    (message "Macher-Agent SECURITY WARNING: Skipped tool '%s' because it contains defun/defvar. Core overrides forbidden." tool-name)
-                                    nil)
-                                (goto-char (point-min))
-                                (condition-case err
-                                    (while t
-                                      (let ((form (read (current-buffer))))
-                                        (setq val (eval form t))))
-                                  (end-of-file (if (and (symbolp val) (boundp val))
-                                                   (symbol-value val)
-                                                 val))
-                                  (error
-                                   (message "Macher-Agent: Failed to load tool %s - %s" tool-name err)
-                                   nil)))))))
-                (when tool
-                  (puthash tool-name tool registry))
-                tool)
-            ;; FIX: Return the string directly to satisfy gptel's (gptel-tool string) constraint
-            tool-name)))))
+         (cached (gethash tool-name registry))
+         (script-paths (delq nil (list
+                                  (when dir-context (expand-file-name (format "scripts/%s.el" tool-name) dir-context))
+                                  (expand-file-name (format "scripts/%s.el" tool-name) macher-agent-bundled-skills-directory))))
+         (vfs-content nil))
+    (catch 'found-vfs
+      (dolist (path script-paths)
+        (let ((content (when context (ignore-errors (macher-agent--read-context-file context path)))))
+          (when content
+            (setq vfs-content content)
+            (throw 'found-vfs t)))))
+    
+    (if vfs-content
+        (macher-agent--evaluate-and-cache-tool vfs-content tool-name registry)
+      (or cached
+          (let ((disk-content nil))
+            (catch 'found-disk
+              (dolist (path script-paths)
+                (when (file-exists-p path)
+                  (with-temp-buffer
+                    (insert-file-contents path)
+                    (setq disk-content (buffer-string))
+                    (throw 'found-disk t)))))
+            (if disk-content
+                (macher-agent--evaluate-and-cache-tool disk-content tool-name registry)
+              tool-name))))))
 
 (defun macher-agent--load-scripts-from-dir (skills-dir context)
   "Load script tools from the scripts subdirectory of SKILLS-DIR."
@@ -232,18 +237,7 @@
                   (list :system body :description desc :model (when model (intern model)) :tools resolved-tools))
             (if workspace
                 (setf (macher-agent-workspace-skills-alist workspace) alist)
-              (setq macher-agent-global-skills-alist alist))
-            
-            ;; Register natively with gptel's UI
-            (setf (alist-get sym gptel-directives) body)
-
-            ;; Generate the full preset if tools are present
-            (when (and tool-names (> (length tool-names) 0))
-              (let ((preset-args (list :system body)))
-                (when desc (setq preset-args (plist-put preset-args :description desc)))
-                (when model (setq preset-args (plist-put preset-args :model (intern model))))
-                (when resolved-tools (setq preset-args (plist-put preset-args :tools resolved-tools)))
-                (apply #'gptel-make-preset sym preset-args)))))))))
+              (setq macher-agent-global-skills-alist alist))))))))
 
 (defun macher-agent-api-register-skills-in-directory (skills-dir &optional context)
   "Scan SKILLS-DIR for SKILL.md files and load them."
@@ -291,8 +285,35 @@
              do (when (file-directory-p d)
                   (macher-agent-api-register-skills-in-directory d context)))
     
-    (when (fboundp 'gptel--setup-directive-menu)
-      (gptel--setup-directive-menu 'gptel--system-message "Agent Profile"))))
+    ;; Sync workspace and global skills to gptel's buffer-local directives
+    (let* ((workspace (when context (macher-agent--get-context-workspace context)))
+           (ws-skills (when workspace (macher-agent-workspace-skills-alist workspace)))
+           (global-skills macher-agent-global-skills-alist)
+           (merged-skills (append ws-skills global-skills)))
+      
+      (unless (local-variable-p 'gptel-directives)
+        (setq-local gptel-directives (copy-tree (default-value 'gptel-directives))))
+      
+      (unless (local-variable-p 'gptel--known-presets)
+        (setq-local gptel--known-presets (copy-tree (default-value 'gptel--known-presets))))
+      
+      (cl-loop for (sym . meta) in merged-skills
+               for system-prompt = (plist-get meta :system)
+               for desc = (plist-get meta :description)
+               for model = (plist-get meta :model)
+               for tools = (plist-get meta :tools)
+               for tool-names = (mapcar (lambda (t_) (if (and (fboundp 'gptel-tool-p) (gptel-tool-p t_)) (gptel-tool-name t_) (if (symbolp t_) (symbol-name t_) t_))) tools)
+               do (when system-prompt
+                    (setf (alist-get sym gptel-directives) system-prompt)
+                    (let ((preset-spec (list :description (or desc (format "Agent Profile: %s" sym))
+                                             :system system-prompt)))
+                      (when model (setq preset-spec (plist-put preset-spec :model model)))
+                      (when tool-names 
+                        (setq preset-spec (plist-put preset-spec :tools `(:append ,tool-names))))
+                      (setf (alist-get sym gptel--known-presets) preset-spec))))))
+  
+  (when (fboundp 'gptel--setup-directive-menu)
+    (gptel--setup-directive-menu 'gptel--system-message "Agent Profile")))
 
 (defun macher-agent--find-native-tool (tool-name)
   "Safely find a gptel-tool registered natively via `gptel-make-tool`."
@@ -322,22 +343,6 @@
                                       (when (equal (replace-regexp-in-string "-" "_" t-name) normalized-target)
                                         (setq found tool)))))))))
     found))
-
-(defun macher-agent-resolve-skill-profile (preset)
-  "Lookup PRESET across workspace, global alists, and gptel's native registry."
-  (when preset
-    (let* ((raw-str (if (symbolp preset) (symbol-name preset) preset))
-           (clean-str (replace-regexp-in-string "^@+" "" raw-str))
-           (clean-sym (intern clean-str))
-           (ctx (ignore-errors (macher-agent-current-context)))
-           (ws (when ctx (macher-agent--get-context-workspace ctx)))
-           (ws-skills (when ws (macher-agent-workspace-skills-alist ws)))
-           (global-skills (bound-and-true-p macher-agent-global-skills-alist))
-           (skill-data (or (alist-get clean-sym ws-skills)
-                           (alist-get clean-sym global-skills)
-                           (gptel-get-preset clean-sym))))
-      (when skill-data
-        (list :sym clean-sym :data skill-data)))))
 
 (defun macher-agent-resolve-to-struct (t-item)
   "Convert a string tool name into a gptel-tool struct strictly from the registry."
@@ -412,13 +417,6 @@
 
 (add-hook 'gptel-mode-hook #'macher-agent-gptel-mode-setup)
 
-(defun macher-agent-sanitise-skill-data (skill-data)
-  "Sanitise a preset plist for gptel: strip :tools, and strip nil :model/:backend to preserve inheritance."
-  (cl-loop for (k v) on skill-data by #'cddr
-           unless (or (memq k '(:tools :context-dir :has-tools :name :name-sym :body :description))
-                      (and (memq k '(:model :backend)) (null v)))
-           append (list k v)))
-
 (defun macher-agent--get-project-root (&optional dir)
   "Resolve the absolute root path of the project for DIR."
   (let* ((d (or dir default-directory))
@@ -435,7 +433,6 @@
          (parent-name (buffer-name parent-buf))
          (parent-mode major-mode)
          (content (buffer-string))
-         (active-skill macher-agent--active-skill-sym)
          (active-backend gptel-backend)
          (active-model gptel-model)
          (active-sys gptel--system-message))
@@ -448,12 +445,9 @@
       ;; meta data to allow users to render buffer trees
       (setq-local macher-agent-parent-buffer parent-name)
       
-      (when active-skill (setq-local macher-agent--active-skill-sym active-skill))
       (when active-backend (setq-local gptel-backend active-backend))
       (when active-model (setq-local gptel-model active-model))
       (when active-sys (setq-local gptel--system-message active-sys))
-      
-      (macher-agent--compose-active-skills)
       
       (switch-to-buffer (current-buffer)))))
 

--- a/macher-agent-gptel-bridge.el
+++ b/macher-agent-gptel-bridge.el
@@ -9,43 +9,15 @@
 (declare-function macher-agent--split-context "macher-agent-vfs-client")
 (declare-function macher-agent--build-virtual-patch "macher-agent-vfs-client")
 
-(defun macher-agent--track-directive-selection (orig-fun sym val scope)
-  "Intercept gptel directive selection to sync our buffer-local skill anchor."
-  (apply orig-fun sym val scope)
-  (when (and (eq sym 'gptel--system-message)
-             (eq scope 'gptel--set-buffer-locally))
-    (let ((skill-sym (macher-agent--get-system-message-name val)))
-      (if skill-sym
-          (setq-local macher-agent--active-skill-sym (intern skill-sym))
-        (setq-local macher-agent--active-skill-sym nil)))))
-
-(defun macher-agent--compose-active-skills ()
-  "JIT Composition: Rebuild buffer-local state right before the LLM request fires."
-  (let ((target-sym (or (bound-and-true-p gptel-directive) 
-                        (bound-and-true-p macher-agent--active-skill-sym))))
-    (when-let* ((profile (macher-agent-resolve-skill-profile target-sym))
-                (skill-data (plist-get profile :data)))
-      
-      ;; FIX: Extracted from when-let* to prevent silent aborts
-      (let* ((tools (plist-get skill-data :tools))
-             (safe-skill-data (macher-agent-sanitise-skill-data skill-data)))
-        
-        (when safe-skill-data
-          (let ((gptel--known-presets (list (cons (or target-sym 'temp) safe-skill-data))))
-            (gptel--apply-preset (or target-sym 'temp) (lambda (sym val) (set (make-local-variable sym) val)))))
-        
-        (when (boundp 'gptel-tools)
-          (let ((buffer-tools gptel-tools))
-            ;; Combine the currently active buffer tools with the preset tools
-            (setq-local gptel-tools (macher-agent-deduplicate-tools (append buffer-tools tools)))))))))
-
 (defun macher-agent--gptel-pre-send-advice (orig-fun &rest args)
-  "Ensure the agent VFS is synchronised and skills are composed before sending."
+  "Ensure the agent VFS is synchronised before sending."
   (let* ((macher-agent--allow-lazy-init t)
          (ctx (macher-agent-current-context)))
-    (when ctx (macher-agent--auto-sync-context ctx))
-    (macher-agent--compose-active-skills))
+    (when ctx (macher-agent--auto-sync-context ctx)))
   (apply orig-fun args))
+
+(advice-add 'gptel-send :around #'macher-agent--gptel-pre-send-advice)
+(advice-add 'gptel-request :around #'macher-agent--gptel-pre-send-advice)
 
 (defun macher-agent-gptel-transmit (task-context callbacks)
   "Facade to transmit network request, attaching async-safe local hooks."
@@ -145,29 +117,44 @@
 (defvar macher-agent--captured-buffer-tools nil
   "Dynamic snapshot of buffer tools.")
 
-(defun macher-agent--merge-preset-and-buffer-tools (fsm)
-  "Transform hook to natively merge buffer tools and preset tools.
-   Runs in the temp prompt buffer immediately after presets have overwritten gptel-tools."
-  (let* ((info (gptel-fsm-info fsm))
-         (orig-buf (plist-get info :buffer))
-         ;; gptel-tools here represents what the preset injected
-         (preset-tools gptel-tools)
-         ;; Reach back to the chat buffer to get the tools you ticked in the menu
-         (buffer-tools (buffer-local-value 'gptel-tools orig-buf)))
-    
-    (when (or buffer-tools preset-tools)
-      ;; Merge them and overwrite the temp buffer's tools. 
-      ;; gptel will natively pick this up when it builds the network payload!
-      (setq-local gptel-tools
-                  (macher-agent-deduplicate-tools (append buffer-tools preset-tools))))))
-
-(add-hook 'gptel-prompt-transform-functions #'macher-agent--merge-preset-and-buffer-tools t)
-
 (defun macher-agent--protect-nil-responses (orig-fun response info &optional raw)
   "Prevent nil string crashes at the point of insertion."
   (funcall orig-fun (or response "") info raw))
 
 (advice-add 'gptel--insert-response :around #'macher-agent--protect-nil-responses)
 (advice-add 'gptel-curl--stream-insert-response :around #'macher-agent--protect-nil-responses)
+
+(defun macher-agent--transform-apply-preset-advice (orig-fun &rest args)
+  "Inject the original buffer's presets, safely padding arguments for sub-agents."
+  (let* ((fsm (car args))
+         (info (when fsm 
+                 (if (fboundp 'gptel-fsm-info) 
+                     (funcall 'gptel-fsm-info fsm) 
+                   (funcall 'mock-gptel-fsm-info fsm))))
+         (orig-buf (if info (plist-get info :buffer) (current-buffer)))
+         (gptel--known-presets (if (buffer-live-p orig-buf) 
+                                   (buffer-local-value 'gptel--known-presets orig-buf) 
+                                 gptel--known-presets))
+         (gptel-directives (if (buffer-live-p orig-buf) 
+                               (buffer-local-value 'gptel-directives orig-buf) 
+                             gptel-directives)))
+    
+    ;; Execute gracefully. If the native function chokes on the delegate's missing/nil 
+    ;; context and throws a stringp error, silently swallow it so the sentinel can finish.
+    (condition-case nil
+        (apply orig-fun (or args (list nil)))
+      (error nil))))
+
+(advice-add 'gptel--transform-apply-preset :around #'macher-agent--transform-apply-preset-advice)
+
+(defun macher-agent--gptel-restore-advice (&rest _)
+  "Ensure workspace skills are loaded into `gptel--known-presets` before restoring."
+  (let ((ctx (when (fboundp 'macher-agent-current-context)
+               (macher-agent-current-context))))
+    (macher-agent-initialize-skills ctx)))
+
+;; Advise the actual internal function that gptel uses on mode startup
+(advice-add 'gptel--restore-state :before #'macher-agent--gptel-restore-advice)
+
 
 (provide 'macher-agent-gptel-bridge)

--- a/macher-agent-orchestration.el
+++ b/macher-agent-orchestration.el
@@ -76,19 +76,11 @@
 
 (defun macher-agent--apply-preset (preset)
   "Apply the PRESET directive securely, flawlessly merging buffer and preset tools."
-  (when-let* ((profile (macher-agent-resolve-skill-profile preset))
-              (skill-data (plist-get profile :data)))
-    
-    (let* ((tools (plist-get skill-data :tools))
-           (safe-skill-data (macher-agent-sanitise-skill-data skill-data)))
-      
-      (when safe-skill-data
-        (let ((gptel--known-presets (list (cons preset safe-skill-data))))
-          (gptel--apply-preset preset (lambda (sym val) (set (make-local-variable sym) val)))))
-      
-      (unless (boundp 'gptel-tools) (setq gptel-tools nil))
-      (make-local-variable 'gptel-tools)
-      (setq gptel-tools (macher-agent-deduplicate-tools (append gptel-tools tools))))))
+  (let* ((raw-str (if (symbolp preset) (symbol-name preset) preset))
+         (clean-str (replace-regexp-in-string "^@+" "" raw-str))
+         (clean-sym (intern clean-str)))
+    (when (gptel-get-preset clean-sym)
+      (gptel--apply-preset clean-sym (lambda (sym val) (set (make-local-variable sym) val))))))
 
 (put 'macher-agent--is-subagent 'permanent-local t)
 (put 'macher-agent--ready-to-reap 'permanent-local t)
@@ -116,14 +108,13 @@
                         (with-current-buffer buf (setq-local macher-agent--ready-to-reap t)))
                       (funcall callback res)))
         
-        (let* ((profile (macher-agent-resolve-skill-profile preset))
-               (final-sym (plist-get profile :sym))
-               (skill-data (plist-get profile :data))
+        (let* ((raw-str (when preset (if (symbolp preset) (symbol-name preset) preset)))
+               (clean-sym (when raw-str (intern (replace-regexp-in-string "^@+" "" raw-str))))
                (task-ctx (make-macher-agent-task-context
                           :workspace nil
                           :target-buffer buf
-                          :skill-sym final-sym
-                          :system-message (if skill-data (plist-get skill-data :system) gptel--system-message))))
+                          :skill-sym clean-sym
+                          :system-message gptel--system-message)))
           
           (macher-agent-gptel-transmit
            task-ctx
@@ -229,8 +220,6 @@
 (add-hook 'gptel-pre-response-hook
           (lambda ()
             (let ((ctx (ignore-errors (macher-agent-current-context))))
-              (when ctx (macher-agent--auto-sync-context ctx)))
-            (when (fboundp 'macher-agent--compose-active-skills)
-              (macher-agent--compose-active-skills))))
+              (when ctx (macher-agent--auto-sync-context ctx)))))
 
 (provide 'macher-agent-orchestration)

--- a/macher-agent.el
+++ b/macher-agent.el
@@ -1,7 +1,7 @@
 ;;; macher-agent.el --- Sandboxed, Language-Agnostic AI Workflows -*- lexical-binding: t; -*-
 
 ;; Author: Elijah Charles
-;; Version: 0.7.8
+;; Version: 0.7.9
 ;; Package-Requires: ((emacs "29.1") (gptel "0.9.0") (macher "0.5.0"))
 ;; Keywords: convenience, gptel, llm, macher
 ;; URL: https://github.com/elij/macher-agent

--- a/tests/macher-agent-skills-test.el
+++ b/tests/macher-agent-skills-test.el
@@ -209,22 +209,26 @@
                           (delete-directory ws-dir t)))
                     
                     (it "applies skill tools correctly into gptel-tools when selected"
-                        (let ((gptel-tools nil)
-                              (mock-tool-obj (if (fboundp 'gptel-make-tool)
-                                                 (gptel-make-tool :name "the_tool" :function (lambda () nil) :description "A tool")
-                                               'the-tool)))
+                        (let* ((gptel-tools nil)
+                               (gptel--known-presets nil)
+                               (gptel-directives nil)
+                               (mock-tool-obj (if (fboundp 'gptel-make-tool)
+                                                  (gptel-make-tool :name "the_tool" :function (lambda () nil) :description "A tool")
+                                                'the-tool)))
                           (spy-on 'gptel-tool-p :and-return-value t)
                           (let* ((ctx (macher-agent-current-context))
-                                 (ws (macher-agent--get-context-workspace ctx)))
-                            (puthash "selected-tool" mock-tool-obj (macher-agent-workspace-tools-registry ws)))
-                          
-                          (let ((workspace (macher-agent--get-context-workspace (macher-agent-current-context))))
+                                 (workspace (macher-agent--get-context-workspace ctx)))
+                            (puthash "selected-tool" mock-tool-obj (macher-agent-workspace-tools-registry workspace))
                             (setf (alist-get 'test-preset (macher-agent-workspace-skills-alist workspace))
-                                  (list :description "test" :tools (list mock-tool-obj) :context-dir nil))
-                            (setq-local macher-agent--active-skill-sym '(test-preset))
-                            (macher-agent--apply-preset 'test-preset))
-                          
-                          (expect gptel-tools :to-equal (list mock-tool-obj))))
+                                  (list :description "test" :system "test system" :tools (list mock-tool-obj) :context-dir nil))
+                            
+                            (with-temp-buffer
+                              (let ((gptel--known-presets nil))
+                                (macher-agent-initialize-skills ctx)
+                                (let ((preset-def (buffer-local-value 'gptel--known-presets (current-buffer))))
+                                  (setq preset-def (alist-get 'test-preset preset-def))
+                                  (expect preset-def :not :to-be nil)
+                                  (expect (plist-get preset-def :tools) :to-equal '(:append ("the_tool")))))))))
 
                     (it "expands org-macros in SKILL.md body"
                         (let* ((parsed (macher-agent-parse-skill-file "tests/fixtures/skills/macro-skill/SKILL.md")))
@@ -236,16 +240,18 @@
                           (make-directory skill-dir t)
                           (with-temp-file (expand-file-name "SKILL.md" skill-dir)
                             (insert "---\nname: my-preset\ndescription: test\nallowed-tools:\n  - some-tool\nmodel: gpt-4o\n---\nPreset body"))
-                          (spy-on 'gptel-make-preset)
-                          (spy-on 'macher-agent-resolve-tool :and-return-value 'mock-tool)
-                          (let ((gptel-directives nil))
-                            (macher-agent-api-register-skills-in-directory mock-dir nil)
-                            (expect 'gptel-make-preset :to-have-been-called)
-                            (let ((args (spy-calls-args-for 'gptel-make-preset 0)))
-                              (expect (car args) :to-equal 'my-preset)
-                              (expect (plist-get (cdr args) :system) :to-equal "Preset body")
-                              (expect (plist-get (cdr args) :model) :to-equal 'gpt-4o))
-                            (delete-directory mock-dir t))))
+                          (spy-on 'macher-agent-resolve-tool :and-return-value "some-tool")
+                          (with-temp-buffer
+                            (let ((gptel-directives nil)
+                                  (gptel--known-presets nil))
+                              (macher-agent-initialize-skills nil mock-dir)
+                              
+                              (let ((preset-def (alist-get 'my-preset gptel--known-presets)))
+                                (expect preset-def :not :to-be nil)
+                                (expect (plist-get preset-def :system) :to-equal "Preset body")
+                                (expect (plist-get preset-def :model) :to-equal 'gpt-4o)
+                                (expect (plist-get preset-def :tools) :to-equal '(:append ("some-tool"))))
+                              (delete-directory mock-dir t)))))
 
                     (it "injects directly into gptel-directives when allowed-tools is omitted"
                         (let* ((mock-dir (make-temp-file "macher-test-skills-directive" t))
@@ -253,9 +259,14 @@
                           (make-directory skill-dir t)
                           (with-temp-file (expand-file-name "SKILL.md" skill-dir)
                             (insert "---\nname: my-directive\n---\nDirective body"))
-                          (let ((gptel-directives nil))
-                            (macher-agent-api-register-skills-in-directory mock-dir nil)
-                            (expect (alist-get 'my-directive gptel-directives) :to-equal "Directive body")
-                            (delete-directory mock-dir t))))))
+                          (with-temp-buffer
+                            (let ((gptel-directives nil)
+                                  (gptel--known-presets nil))
+                              (macher-agent-initialize-skills nil mock-dir)
+                              (expect (alist-get 'my-directive gptel-directives) :to-equal "Directive body")
+                              (let ((preset-def (alist-get 'my-directive gptel--known-presets)))
+                                (expect preset-def :not :to-be nil)
+                                (expect (plist-get preset-def :system) :to-equal "Directive body"))
+                              (delete-directory mock-dir t)))))))
 
 (provide 'macher-agent-skills-test)

--- a/tests/macher-agent-test.el
+++ b/tests/macher-agent-test.el
@@ -11,624 +11,638 @@
 
 (describe "Macher-Agent BDD Test Suite"
 
-  (before-each
-    (spy-on 'macher-action)
-    (spy-on 'gptel-send)
-    (spy-on 'macher--add-termination-handler)
-    (setq macher-agent--persistent-context nil)
-    (let* ((ctx (ignore-errors (macher-agent-current-context)))
-           (ws (when ctx (macher-agent--get-context-workspace ctx))))
-      (when ws (setf (macher-agent-workspace-active-subagents ws) nil))))
+          (before-each
+           (spy-on 'macher-action)
+           (spy-on 'gptel-send)
+           (spy-on 'macher--add-termination-handler)
+           (setq macher-agent--persistent-context nil)
+           (let* ((ctx (ignore-errors (macher-agent-current-context)))
+                  (ws (when ctx (macher-agent--get-context-workspace ctx))))
+             (when ws (setf (macher-agent-workspace-active-subagents ws) nil))))
 
-  (describe "Context & Security (macher-agent-vfs-client.el)"
-    (it "throws a security error if accessing a path outside of the allowed context"
-      (let ((ctx (macher--make-context :contents '(("allowed.txt" . ("old" . "new"))))))
-        (expect (macher-agent--ensure-access ctx "forbidden.txt") :to-throw 'error)))
+          (describe "Context & Security (macher-agent-vfs-client.el)"
+                    (it "throws a security error if accessing a path outside of the allowed context"
+                        (let ((ctx (macher--make-context :contents '(("allowed.txt" . ("old" . "new"))))))
+                          (expect (macher-agent--ensure-access ctx "forbidden.txt") :to-throw 'error)))
 
-    (it "successfully records a virtual edit to an existing scoped buffer"
-      (let* ((ctx (macher--make-context :contents '(("test.txt" . ("orig" . "orig"))))))
-        (macher-agent--update-context-file ctx "test.txt" "modified")
-        (expect (macher-context-dirty-p ctx) :to-be t)
-        (expect (cdr (cdr (assoc "test.txt" (macher-context-contents ctx)))) :to-equal "modified")))
+                    (it "successfully records a virtual edit to an existing scoped buffer"
+                        (let* ((ctx (macher--make-context :contents '(("test.txt" . ("orig" . "orig"))))))
+                          (macher-agent--update-context-file ctx "test.txt" "modified")
+                          (expect (macher-context-dirty-p ctx) :to-be t)
+                          (expect (cdr (cdr (assoc "test.txt" (macher-context-contents ctx)))) :to-equal "modified")))
 
-    (describe "Three-way Merge Logic"
-      (it "invalidates the local cache if both local and remote diverged"
-        (let* ((test-dir (make-temp-file "macher-test-dir" t))
-               (test-file (expand-file-name "test.txt" test-dir))
-               (ctx (macher--make-context :dirty-p t)))
-          
-          (setf (macher-context-contents ctx) 
-                (list (cons test-file (cons "v1" "v2-local"))))
-          
-          (with-temp-file test-file (insert "v2-remote"))
-          
-          (macher-agent--auto-sync-context ctx)
-          
-          (let ((pair (cdr (assoc test-file (macher-context-contents ctx)))))
-            (expect (car pair) :to-equal "v2-remote")
-            (expect (cdr pair) :to-equal "v2-remote"))
-          
-          (delete-directory test-dir t)))
+                    (describe "Three-way Merge Logic"
+                              (it "invalidates the local cache if both local and remote diverged"
+                                  (let* ((test-dir (make-temp-file "macher-test-dir" t))
+                                         (test-file (expand-file-name "test.txt" test-dir))
+                                         (ctx (macher--make-context :dirty-p t)))
+                                    
+                                    (setf (macher-context-contents ctx) 
+                                          (list (cons test-file (cons "v1" "v2-local"))))
+                                    
+                                    (with-temp-file test-file (insert "v2-remote"))
+                                    
+                                    (macher-agent--auto-sync-context ctx)
+                                    
+                                    (let ((pair (cdr (assoc test-file (macher-context-contents ctx)))))
+                                      (expect (car pair) :to-equal "v2-remote")
+                                      (expect (cdr pair) :to-equal "v2-remote"))
+                                    
+                                    (delete-directory test-dir t)))
 
-      (it "preserves unapplied virtual edits across tool calls if the physical state has not mutated"
-        (let* ((content-pair (cons "original state" "proposed ghost state"))
-               (entry (cons "test-file.el" content-pair)))
-          
-          ;; Mock the disk returning the exact same original state
-          (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "original state")
-          
-          (macher-agent--sync-context-entry entry)
-          
-          ;; The agent's unapplied virtual edit MUST survive!
-          (expect (cddr entry) :to-equal "proposed ghost state")))
+                              (it "preserves unapplied virtual edits across tool calls if the physical state has not mutated"
+                                  (let* ((content-pair (cons "original state" "proposed ghost state"))
+                                         (entry (cons "test-file.el" content-pair)))
+                                    
+                                    ;; Mock the disk returning the exact same original state
+                                    (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "original state")
+                                    
+                                    (macher-agent--sync-context-entry entry)
+                                    
+                                    ;; The agent's unapplied virtual edit MUST survive!
+                                    (expect (cddr entry) :to-equal "proposed ghost state")))
 
-      (it "invalidates edits and prevents ghost diffs if the underlying buffer or file is destroyed"
-        (let* ((content-pair (cons "original state" "proposed ghost state"))
-               (entry (cons "test-file.el" content-pair)))
-          
-          ;; Mock the buffer being killed or file being deleted (returns nil)
-          (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value nil)
-          
-          (macher-agent--sync-context-entry entry)
-          
-          ;; The concurrency control detects the change and wipes the ghost edits
-          (expect (cadr entry) :to-be nil)
-          (expect (cddr entry) :to-be nil)))
+                              (it "invalidates edits and prevents ghost diffs if the underlying buffer or file is destroyed"
+                                  (let* ((content-pair (cons "original state" "proposed ghost state"))
+                                         (entry (cons "test-file.el" content-pair)))
+                                    
+                                    ;; Mock the buffer being killed or file being deleted (returns nil)
+                                    (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value nil)
+                                    
+                                    (macher-agent--sync-context-entry entry)
+                                    
+                                    ;; The concurrency control detects the change and wipes the ghost edits
+                                    (expect (cadr entry) :to-be nil)
+                                    (expect (cddr entry) :to-be nil)))
 
-      (it "splits pure buffers from physical files for independent diff generation"
-        (let* ((ctx (macher--make-context))
-               (file-path (expand-file-name "dummy-file.txt" temporary-file-directory))
-               (pure-name "*macher-dummy-buf*")
-               (file-buf (find-file-noselect file-path))
-               (pure-buf (get-buffer-create pure-name)))
-          
-          ;; 1. Add one physical file and one pure buffer to the context
-          (push (cons file-path (cons "a" "b")) (macher-context-contents ctx))
-          (push (cons pure-name (cons "x" "y")) (macher-context-contents ctx))
-          (expect (length (macher-context-contents ctx)) :to-equal 2)
-          
-          ;; 2. Run the splitter
-          (let* ((split (macher-agent--split-context ctx))
-                 (file-ctx (car split))
-                 (buf-ctx (cdr split)))
-            
-            ;; 3. Verify physical files went to the left (car)
-            (expect (length (macher-context-contents file-ctx)) :to-equal 1)
-            (expect (assoc file-path (macher-context-contents file-ctx)) :to-be-truthy)
-            (expect (assoc pure-name (macher-context-contents file-ctx)) :to-be nil)
-            
-            ;; 4. Verify pure buffers went to the right (cdr)
-            (expect (assoc pure-name (macher-context-contents buf-ctx)) :to-be-truthy)
-            (expect (assoc file-path (macher-context-contents buf-ctx)) :to-be nil))
-          
-          (kill-buffer file-buf)
-          (kill-buffer pure-buf)))
+                              (it "splits pure buffers from physical files for independent diff generation"
+                                  (let* ((ctx (macher--make-context))
+                                         (file-path (expand-file-name "dummy-file.txt" temporary-file-directory))
+                                         (pure-name "*macher-dummy-buf*")
+                                         (file-buf (find-file-noselect file-path))
+                                         (pure-buf (get-buffer-create pure-name)))
+                                    
+                                    ;; 1. Add one physical file and one pure buffer to the context
+                                    (push (cons file-path (cons "a" "b")) (macher-context-contents ctx))
+                                    (push (cons pure-name (cons "x" "y")) (macher-context-contents ctx))
+                                    (expect (length (macher-context-contents ctx)) :to-equal 2)
+                                    
+                                    ;; 2. Run the splitter
+                                    (let* ((split (macher-agent--split-context ctx))
+                                           (file-ctx (car split))
+                                           (buf-ctx (cdr split)))
+                                      
+                                      ;; 3. Verify physical files went to the left (car)
+                                      (expect (length (macher-context-contents file-ctx)) :to-equal 1)
+                                      (expect (assoc file-path (macher-context-contents file-ctx)) :to-be-truthy)
+                                      (expect (assoc pure-name (macher-context-contents file-ctx)) :to-be nil)
+                                      
+                                      ;; 4. Verify pure buffers went to the right (cdr)
+                                      (expect (assoc pure-name (macher-context-contents buf-ctx)) :to-be-truthy)
+                                      (expect (assoc file-path (macher-context-contents buf-ctx)) :to-be nil))
+                                    
+                                    (kill-buffer file-buf)
+                                    (kill-buffer pure-buf)))
 
-      (it "triggers the UI safely on completion without modifying the FSM"
-        (let* ((buf (generate-new-buffer "test-bridge"))
-               (ctx (macher--make-context :dirty-p t))
-               (file-path (expand-file-name "test.txt")))
-          (push (cons file-path (cons "old" "new")) (macher-context-contents ctx))
-          
-          (with-current-buffer buf
-            (setq-local macher-agent--is-workspace t)
-            (setq-local macher-agent--persistent-context ctx)
-            (setq-local macher--fsm-latest nil))
-          
-          (with-current-buffer buf
-            (macher-agent-apply-virtual-buffers))
-          (kill-buffer buf))))
-    (describe "Macher-Agent Skill Model Selection"
+                              (it "triggers the UI safely on completion without modifying the FSM"
+                                  (let* ((buf (generate-new-buffer "test-bridge"))
+                                         (ctx (macher--make-context :dirty-p t))
+                                         (file-path (expand-file-name "test.txt")))
+                                    (push (cons file-path (cons "old" "new")) (macher-context-contents ctx))
+                                    
+                                    (with-current-buffer buf
+                                      (setq-local macher-agent--is-workspace t)
+                                      (setq-local macher-agent--persistent-context ctx)
+                                      (setq-local macher--fsm-latest nil))
+                                    
+                                    (with-current-buffer buf
+                                      (macher-agent-apply-virtual-buffers))
+                                    (kill-buffer buf))))
+                    (describe "Macher-Agent Skill Model Selection"
 
-      (it "applies the correct model from the skill metadata to gptel-model"
-        (spy-on 'macher-agent-current-context :and-return-value
-                (macher-agent--make-vfs-context :workspace (make-macher-agent-workspace :project-root "/mock/proj") :contents nil))
-        (let* ((skill-name 'rust-skill)
-               ;; Register a skill with a specific model
-               (skill-data '(:description "Test" :model gpt-4o :has-tools nil :context-dir nil :body "test"))
-               (execution (macher--make-action-execution :action skill-name)))
-          
-          (let ((workspace (macher-agent--get-context-workspace (macher-agent-current-context))))
-            (setf (alist-get skill-name (macher-agent-workspace-skills-alist workspace)) skill-data))
-          
-          ;; Execute the advice
-          (with-temp-buffer
-            (let ((macher-agent--active-skill-sym (list skill-name)))
-              (macher-agent--apply-preset skill-name))
-            
-            ;; Assert that the local variable was set to the model from the metadata
-            (expect gptel-model :to-equal 'gpt-4o))))
+                              (it "applies the correct model from the skill metadata to gptel-model"
+                                  (spy-on 'macher-agent-current-context :and-return-value
+                                          (macher-agent--make-vfs-context :workspace (make-macher-agent-workspace :project-root "/mock/proj") :contents nil))
+                                  (let* ((skill-name 'rust-skill)
+                                         ;; Register a skill with a specific model
+                                         (skill-data '(:description "Test" :model gpt-4o :has-tools nil :context-dir nil :system "test"))
+                                         (execution (macher--make-action-execution :action skill-name)))
+                                    
+                                    (let ((workspace (macher-agent--get-context-workspace (macher-agent-current-context))))
+                                      (setf (alist-get skill-name (macher-agent-workspace-skills-alist workspace)) skill-data))
+                                    
+                                    ;; Execute the initialization
+                                    (with-temp-buffer
+                                      (let ((gptel--known-presets nil))
+                                        (macher-agent-initialize-skills (macher-agent-current-context))
+                                        
+                                        (let ((preset-def (alist-get skill-name gptel--known-presets)))
+                                          (expect preset-def :not :to-be nil)
+                                          (expect (plist-get preset-def :model) :to-equal 'gpt-4o))))))
 
-      (it "does not change gptel-model if no model is specified in the skill"
-        (spy-on 'macher-agent-current-context :and-return-value
-                (macher-agent--make-vfs-context :workspace (make-macher-agent-workspace :project-root "/mock/proj") :contents nil))
-        (let* ((skill-name 'plain-skill)
-               ;; Register a skill with NO model
-               (skill-data '(:description "Test" :model nil :has-tools nil :context-dir nil :body "test"))
-               (execution (macher--make-action-execution :action skill-name))
-               (original-model gptel-model))
-          
-          (let ((workspace (macher-agent--get-context-workspace (macher-agent-current-context))))
-            (setf (alist-get skill-name (macher-agent-workspace-skills-alist workspace)) skill-data))
-          
-          (with-temp-buffer
-            (setq-local gptel-model original-model)
-            (let ((macher-agent--active-skill-sym (list skill-name)))
-              (macher-agent--apply-preset skill-name))
-            
-            ;; Assert that the model remains unchanged
-            (expect gptel-model :to-equal original-model)))))
-    (describe "Virtual File System (VFS) Concurrency Control"
-      
-      (describe "macher-agent--sync-context-entry"
-        
-        (it "preserves unapplied virtual edits if the physical disk has NOT mutated"
-          (let* ((content-pair (cons "original state" "agent edit"))
-                 (entry (cons "test.el" content-pair)))
-            
-            ;; Mock the disk returning the exact same original state
-            (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "original state")
-            
-            (let ((mutated (macher-agent--sync-context-entry entry)))
-              (expect mutated :to-be nil)
-              (expect (cadr entry) :to-equal "original state")
-              (expect (cddr entry) :to-equal "agent edit"))))
+                              (it "does not change gptel-model if no model is specified in the skill"
+                                  (spy-on 'macher-agent-current-context :and-return-value
+                                          (macher-agent--make-vfs-context :workspace (make-macher-agent-workspace :project-root "/mock/proj") :contents nil))
+                                  (let* ((skill-name 'plain-skill)
+                                         ;; Register a skill with NO model
+                                         (skill-data '(:description "Test" :model nil :has-tools nil :context-dir nil :system "test"))
+                                         (execution (macher--make-action-execution :action skill-name))
+                                         (original-model gptel-model))
+                                    
+                                    (let ((workspace (macher-agent--get-context-workspace (macher-agent-current-context))))
+                                      (setf (alist-get skill-name (macher-agent-workspace-skills-alist workspace)) skill-data))
+                                    
+                                    (with-temp-buffer
+                                      (let ((gptel--known-presets nil))
+                                        (macher-agent-initialize-skills (macher-agent-current-context))
+                                        
+                                        (let ((preset-def (alist-get skill-name gptel--known-presets)))
+                                          (expect preset-def :not :to-be nil)
+                                          ;; plist-member returns the tail if found, nil if not. Since model is not present, it should not exist in the plist.
+                                          (expect (plist-member preset-def :model) :to-be nil)))))))
+                    (describe "Virtual File System (VFS) Concurrency Control"
+                              
+                              (describe "macher-agent--sync-context-entry"
+                                        
+                                        (it "preserves unapplied virtual edits if the physical disk has NOT mutated"
+                                            (let* ((content-pair (cons "original state" "agent edit"))
+                                                   (entry (cons "test.el" content-pair)))
+                                              
+                                              ;; Mock the disk returning the exact same original state
+                                              (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "original state")
+                                              
+                                              (let ((mutated (macher-agent--sync-context-entry entry)))
+                                                (expect mutated :to-be nil)
+                                                (expect (cadr entry) :to-equal "original state")
+                                                (expect (cddr entry) :to-equal "agent edit"))))
 
-        (it "fast-forwards a clean virtual memory if the physical disk mutates naturally"
-          (let* ((content-pair (cons "original state" "original state"))
-                 (entry (cons "test.el" content-pair)))
-            
-            ;; Mock a physical edit happening while the agent had NO pending edits
-            (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "new physical state")
-            
-            (let ((mutated (macher-agent--sync-context-entry entry)))
-              (expect mutated :to-be t)
-              (expect (cadr entry) :to-equal "new physical state")
-              (expect (cddr entry) :to-equal "new physical state"))))
+                                        (it "fast-forwards a clean virtual memory if the physical disk mutates naturally"
+                                            (let* ((content-pair (cons "original state" "original state"))
+                                                   (entry (cons "test.el" content-pair)))
+                                              
+                                              ;; Mock a physical edit happening while the agent had NO pending edits
+                                              (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "new physical state")
+                                              
+                                              (let ((mutated (macher-agent--sync-context-entry entry)))
+                                                (expect mutated :to-be t)
+                                                (expect (cadr entry) :to-equal "new physical state")
+                                                (expect (cddr entry) :to-equal "new physical state"))))
 
-        (it "OPTIMISTIC CONCURRENCY: invalidates virtual edits if a hostile physical mutation occurs"
-          (let* ((content-pair (cons "original state" "agent edit"))
-                 (entry (cons "test.el" content-pair)))
-            
-            ;; Mock the user manually editing the file while the agent was thinking
-            (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "user physical edit")
-            
-            (let ((mutated (macher-agent--sync-context-entry entry)))
-              ;; The system MUST detect the conflict and aggressively drop the agent's delta
-              (expect mutated :to-be t)
-              (expect (cadr entry) :to-equal "user physical edit")
-              (expect (cddr entry) :to-equal "user physical edit"))))
+                                        (it "OPTIMISTIC CONCURRENCY: invalidates virtual edits if a hostile physical mutation occurs"
+                                            (let* ((content-pair (cons "original state" "agent edit"))
+                                                   (entry (cons "test.el" content-pair)))
+                                              
+                                              ;; Mock the user manually editing the file while the agent was thinking
+                                              (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "user physical edit")
+                                              
+                                              (let ((mutated (macher-agent--sync-context-entry entry)))
+                                                ;; The system MUST detect the conflict and aggressively drop the agent's delta
+                                                (expect mutated :to-be t)
+                                                (expect (cadr entry) :to-equal "user physical edit")
+                                                (expect (cddr entry) :to-equal "user physical edit"))))
 
-        (it "fast-forwards virtual memory if the physical mutation perfectly matches the virtual delta (patch applied)"
-          (let* ((content-pair (cons "original state" "agent edit"))
-                 (entry (cons "test.el" content-pair)))
-            
-            ;; Mock the state immediately after the user applies the patch.
-            ;; The disk now matches the agent's unapplied edit perfectly.
-            (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "agent edit")
-            
-            (let ((mutated (macher-agent--sync-context-entry entry)))
-              ;; The system MUST recognise the patch was applied and fast-forward the baseline.
-              ;; It returns t (mutated) and updates orig to match new, preventing duplicate patches.
-              (expect mutated :to-be t)
-              (expect (cadr entry) :to-equal "agent edit")
-              (expect (cddr entry) :to-equal "agent edit")))))
+                                        (it "fast-forwards virtual memory if the physical mutation perfectly matches the virtual delta (patch applied)"
+                                            (let* ((content-pair (cons "original state" "agent edit"))
+                                                   (entry (cons "test.el" content-pair)))
+                                              
+                                              ;; Mock the state immediately after the user applies the patch.
+                                              ;; The disk now matches the agent's unapplied edit perfectly.
+                                              (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "agent edit")
+                                              
+                                              (let ((mutated (macher-agent--sync-context-entry entry)))
+                                                ;; The system MUST recognise the patch was applied and fast-forward the baseline.
+                                                ;; It returns t (mutated) and updates orig to match new, preventing duplicate patches.
+                                                (expect mutated :to-be t)
+                                                (expect (cadr entry) :to-equal "agent edit")
+                                                (expect (cddr entry) :to-equal "agent edit")))))
 
-      )
-    (describe "Macher-Agent Tool Registry Resilience"
-      
-      (it "ensures custom tools survive the preset purge and retain correct category"
-        (let* (;; 1. Define a tool mimicking your agent tools
-               (custom-tool (gptel-make-tool 
-                             :name "cargo_check_tool" 
-                             :function #'ignore 
-                             :category "macher-agent-rust" 
-                             :description "Test tool" 
-                             :args nil))
-               ;; 2. Simulate the clearing function used by presets like macher-ro
-               (clear-fn (plist-get (plist-get macher--preset-clear-tools :tools) :function))
-               ;; 3. Simulate a scenario where a preset attempts to purge everything but 'macher' category tools
-               (tools-list (list custom-tool 
-                                 (gptel-make-tool :name "native_tool" :function #'ignore :category "macher" :description "native" :args nil)))
-               (filtered-tools (funcall clear-fn tools-list)))
-          
-          ;; PROOF: The custom tool MUST survive because it does not match the 'macher' category purge
-          (expect (seq-find (lambda (tool) (string= (gptel-tool-name tool) "cargo_check_tool")) filtered-tools) :not :to-be nil)
-          (expect (gptel-tool-category custom-tool) :to-equal "macher-agent-rust")))
+                              )
+                    (describe "Macher-Agent Tool Registry Resilience"
+                              
+                              (it "ensures custom tools survive the preset purge and retain correct category"
+                                  (let* (;; 1. Define a tool mimicking your agent tools
+                                         (custom-tool (gptel-make-tool 
+                                                       :name "cargo_check_tool" 
+                                                       :function #'ignore 
+                                                       :category "macher-agent-rust" 
+                                                       :description "Test tool" 
+                                                       :args nil))
+                                         ;; 2. Simulate the clearing function used by presets like macher-ro
+                                         (clear-fn (plist-get (plist-get macher--preset-clear-tools :tools) :function))
+                                         ;; 3. Simulate a scenario where a preset attempts to purge everything but 'macher' category tools
+                                         (tools-list (list custom-tool 
+                                                           (gptel-make-tool :name "native_tool" :function #'ignore :category "macher" :description "native" :args nil)))
+                                         (filtered-tools (funcall clear-fn tools-list)))
+                                    
+                                    ;; PROOF: The custom tool MUST survive because it does not match the 'macher' category purge
+                                    (expect (seq-find (lambda (tool) (string= (gptel-tool-name tool) "cargo_check_tool")) filtered-tools) :not :to-be nil)
+                                    (expect (gptel-tool-category custom-tool) :to-equal "macher-agent-rust")))
 
-      (it "verifies that tools identified as 'macher' category get context injected"
-        (let* ((mock-fsm (gptel-make-fsm))
-               (mock-tool (gptel-make-tool :name "test_tool" 
-                                           :function (lambda (ctx) ctx) 
-                                           :category "macher" 
-                                           :description "test" :args nil))
-               (mock-context 'injected-context))
-          
-          (setf (gptel-fsm-info mock-fsm) (list :tools (list mock-tool) :buffer (current-buffer)))
-          
-          ;; Run the macher setup logic
-          (macher--setup-tools mock-fsm (lambda () mock-context))
-          
-          (let* ((processed-tools (plist-get (gptel-fsm-info mock-fsm) :tools))
-                 (processed-tool (car processed-tools)))
-            
-            ;; PROOF: The tool has been wrapped and is now expecting the context
-            (expect (funcall (gptel-tool-function processed-tool)) :to-equal 'injected-context)))))
-    (describe "Sandbox Execution (macher-agent-vfs-client.el)"
-      (describe "read_media_in_workspace"
-        (it "errors if gptel-track-media is nil"
-          (let* ((gptel-track-media nil)
-                 (ctx (macher--make-context :contents '(("test.png" . ("" . "img-data")))))
-                 (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
-            (spy-on 'macher-agent-current-context :and-return-value ctx)
-            (let ((result (funcall tool-fn "test.png")))
-              (expect result :to-match "gptel media send option is off"))))
-        (it "permits access to valid media files inside the workspace without triggering VFS text security locks"
-          (let* ((gptel-track-media t)
-                 (session (make-macher-agent-session :id "test"))
-                 (macher--fsm-latest 'mock-fsm)
-                 (mock-info (list :macher-agent-session session))
-                 (ctx (macher--make-context :contents nil))
-                 (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
-            (spy-on 'gptel-fsm-info :and-return-value mock-info)
-            (spy-on 'macher-agent-current-context :and-return-value ctx)
-            (spy-on 'macher-agent-context-classify-entry :and-return-value 'media)
-            (spy-on 'file-exists-p :and-return-value t)
-            (spy-on 'mailcap-file-name-to-mime-type :and-return-value "image/png")
-            (let ((result (funcall tool-fn "test_workspace_image.png")))
-              (expect result :to-match "SUCCESS: Media 'test_workspace_image.png'"))))
-        (it "throws an error if the tool cannot determine MIME type"
-          (let* ((gptel-track-media t)
-                 (ctx (macher--make-context :contents nil))
-                 (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
-            (spy-on 'macher-agent-current-context :and-return-value ctx)
-            (spy-on 'file-exists-p :and-return-value t)
-            (spy-on 'mailcap-file-name-to-mime-type :and-return-value nil)
-            (let ((result (funcall tool-fn "unauthorized_script.sh")))
-              (expect result :to-match "Could not determine MIME type"))))
-        (it "stages media in the session pending-media instead of polluting gptel-context"
-          (let* ((gptel-track-media t)
-                 (gptel-context nil)
-                 (session (make-macher-agent-session :id "test"))
-                 (macher--fsm-latest 'mock-fsm)
-                 (mock-info (list :macher-agent-session session))
-                 (ctx (macher--make-context :contents '(("test.png" . ("" . "img-data")))))
-                 (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
-            (spy-on 'gptel-fsm-info :and-return-value mock-info)
-            (spy-on 'macher-agent-current-context :and-return-value ctx)
-            (spy-on 'mailcap-file-name-to-mime-type :and-return-value "image/png")
-            (spy-on 'file-exists-p :and-return-value t)
-            (let ((result (funcall tool-fn "test.png")))
-              (expect result :to-match "SUCCESS: Media")
-              (expect gptel-context :to-be nil)
-              (expect (macher-agent-session-pending-media session) :to-be-truthy))))
+                              (it "verifies that tools identified as 'macher' category get context injected"
+                                  (let* ((mock-fsm (gptel-make-fsm))
+                                         (mock-tool (gptel-make-tool :name "test_tool" 
+                                                                     :function (lambda (ctx) ctx) 
+                                                                     :category "macher" 
+                                                                     :description "test" :args nil))
+                                         (mock-context 'injected-context))
+                                    
+                                    (setf (gptel-fsm-info mock-fsm) (list :tools (list mock-tool) :buffer (current-buffer)))
+                                    
+                                    ;; Run the macher setup logic
+                                    (macher--setup-tools mock-fsm (lambda () mock-context))
+                                    
+                                    (let* ((processed-tools (plist-get (gptel-fsm-info mock-fsm) :tools))
+                                           (processed-tool (car processed-tools)))
+                                      
+                                      ;; PROOF: The tool has been wrapped and is now expecting the context
+                                      (expect (funcall (gptel-tool-function processed-tool)) :to-equal 'injected-context)))))
+                    (describe "Sandbox Execution (macher-agent-vfs-client.el)"
+                              (describe "read_media_in_workspace"
+                                        (it "errors if gptel-track-media is nil"
+                                            (let* ((gptel-track-media nil)
+                                                   (ctx (macher--make-context :contents '(("test.png" . ("" . "img-data")))))
+                                                   (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
+                                              (spy-on 'macher-agent-current-context :and-return-value ctx)
+                                              (let ((result (funcall tool-fn "test.png")))
+                                                (expect result :to-match "gptel media send option is off"))))
+                                        (it "permits access to valid media files inside the workspace without triggering VFS text security locks"
+                                            (let* ((gptel-track-media t)
+                                                   (session (make-macher-agent-session :id "test"))
+                                                   (macher--fsm-latest 'mock-fsm)
+                                                   (mock-info (list :macher-agent-session session))
+                                                   (ctx (macher--make-context :contents nil))
+                                                   (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
+                                              (spy-on 'gptel-fsm-info :and-return-value mock-info)
+                                              (spy-on 'macher-agent-current-context :and-return-value ctx)
+                                              (spy-on 'macher-agent-context-classify-entry :and-return-value 'media)
+                                              (spy-on 'file-exists-p :and-return-value t)
+                                              (spy-on 'mailcap-file-name-to-mime-type :and-return-value "image/png")
+                                              (let ((result (funcall tool-fn "test_workspace_image.png")))
+                                                (expect result :to-match "SUCCESS: Media 'test_workspace_image.png'"))))
+                                        (it "throws an error if the tool cannot determine MIME type"
+                                            (let* ((gptel-track-media t)
+                                                   (ctx (macher--make-context :contents nil))
+                                                   (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
+                                              (spy-on 'macher-agent-current-context :and-return-value ctx)
+                                              (spy-on 'file-exists-p :and-return-value t)
+                                              (spy-on 'mailcap-file-name-to-mime-type :and-return-value nil)
+                                              (let ((result (funcall tool-fn "unauthorized_script.sh")))
+                                                (expect result :to-match "Could not determine MIME type"))))
+                                        (it "stages media in the session pending-media instead of polluting gptel-context"
+                                            (let* ((gptel-track-media t)
+                                                   (gptel-context nil)
+                                                   (session (make-macher-agent-session :id "test"))
+                                                   (macher--fsm-latest 'mock-fsm)
+                                                   (mock-info (list :macher-agent-session session))
+                                                   (ctx (macher--make-context :contents '(("test.png" . ("" . "img-data")))))
+                                                   (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
+                                              (spy-on 'gptel-fsm-info :and-return-value mock-info)
+                                              (spy-on 'macher-agent-current-context :and-return-value ctx)
+                                              (spy-on 'mailcap-file-name-to-mime-type :and-return-value "image/png")
+                                              (spy-on 'file-exists-p :and-return-value t)
+                                              (let ((result (funcall tool-fn "test.png")))
+                                                (expect result :to-match "SUCCESS: Media")
+                                                (expect gptel-context :to-be nil)
+                                                (expect (macher-agent-session-pending-media session) :to-be-truthy))))
 
-        (it "injects pending media into FSM payload and clears the queue pre-flight"
-          (let* ((buf (current-buffer))
-                 (mock-backend 'mock-backend)
-                 (mock-data '((:role "system" :content "sys")))
-                 (session (make-macher-agent-session :id "test" :pending-media '(("/test.png" :mime "image/png"))))
-                 (mock-info (list :buffer buf :backend mock-backend :data mock-data :macher-agent-session session))
-                 
-                 ;; We can safely use a mock symbol again!
-                 (mock-fsm 'mock-fsm)
-                 
-                 (orig-called nil)
-                 (orig-fun (lambda (fsm &rest _) (setq orig-called fsm))))
-            
-            ;; Spy on the accessor to intercept the dynamic funcall
-            (spy-on 'gptel-fsm-info :and-return-value mock-info)
-            (spy-on 'gptel--inject-media)
-            (spy-on 'gptel--inject-prompt)
-            
-            ;; Execute the restored advice
-            (macher-agent--inject-media-fsm-advice orig-fun mock-fsm)
-            
-            ;; Verify injection lifecycle
-            (expect 'gptel-fsm-info :to-have-been-called-with mock-fsm)
-            (expect 'gptel--inject-media :to-have-been-called)
-            (expect 'gptel--inject-prompt :to-have-been-called)
-            (expect orig-called :to-equal mock-fsm)
-            (expect (macher-agent-session-pending-media session) :to-be nil))))
+                                        (it "injects pending media into FSM payload and clears the queue pre-flight"
+                                            (let* ((buf (current-buffer))
+                                                   (mock-backend 'mock-backend)
+                                                   (mock-data '((:role "system" :content "sys")))
+                                                   (session (make-macher-agent-session :id "test" :pending-media '(("/test.png" :mime "image/png"))))
+                                                   (mock-info (list :buffer buf :backend mock-backend :data mock-data :macher-agent-session session))
+                                                   
+                                                   ;; We can safely use a mock symbol again!
+                                                   (mock-fsm 'mock-fsm)
+                                                   
+                                                   (orig-called nil)
+                                                   (orig-fun (lambda (fsm &rest _) (setq orig-called fsm))))
+                                              
+                                              ;; Spy on the accessor to intercept the dynamic funcall
+                                              (spy-on 'gptel-fsm-info :and-return-value mock-info)
+                                              (spy-on 'gptel--inject-media)
+                                              (spy-on 'gptel--inject-prompt)
+                                              
+                                              ;; Execute the restored advice
+                                              (macher-agent--inject-media-fsm-advice orig-fun mock-fsm)
+                                              
+                                              ;; Verify injection lifecycle
+                                              (expect 'gptel-fsm-info :to-have-been-called-with mock-fsm)
+                                              (expect 'gptel--inject-media :to-have-been-called)
+                                              (expect 'gptel--inject-prompt :to-have-been-called)
+                                              (expect orig-called :to-equal mock-fsm)
+                                              (expect (macher-agent-session-pending-media session) :to-be nil))))
 
-      (describe "rsync command building"
-        
-        (it "constructs a shell string using git ls-files"
-          ;; Intercept call-process to return 0 (success).
-          ;; This simulates a valid git repository and bypasses the physical directory check.
-          (spy-on 'call-process :and-return-value 0)
-          
-          (let* ((src "/my/project/")
-                 (dest "/tmp/sandbox/")
-                 (cmd (macher-agent--build-rsync-cmd src dest)))
-            
-            (expect (stringp cmd) :to-be t)
-            (expect (string-match-p "git ls-files" cmd) :to-be-truthy)
-            (expect (string-match-p "rsync -aLC --delete --files-from=-" cmd) :to-be-truthy)
-            
-            ;; Optional but good practice: verify our mock was actually triggered
-            (expect 'call-process :to-have-been-called-with
-                    "git" nil nil nil "rev-parse" "--is-inside-work-tree")))))
+                              (describe "rsync command building"
+                                        
+                                        (it "constructs a shell string using git ls-files"
+                                            ;; Intercept call-process to return 0 (success).
+                                            ;; This simulates a valid git repository and bypasses the physical directory check.
+                                            (spy-on 'call-process :and-return-value 0)
+                                            
+                                            (let* ((src "/my/project/")
+                                                   (dest "/tmp/sandbox/")
+                                                   (cmd (macher-agent--build-rsync-cmd src dest)))
+                                              
+                                              (expect (stringp cmd) :to-be t)
+                                              (expect (string-match-p "git ls-files" cmd) :to-be-truthy)
+                                              (expect (string-match-p "rsync -aLC --delete --files-from=-" cmd) :to-be-truthy)
+                                              
+                                              ;; Optional but good practice: verify our mock was actually triggered
+                                              (expect 'call-process :to-have-been-called-with
+                                                      "git" nil nil nil "rev-parse" "--is-inside-work-tree")))))
 
-    (describe "Macher-Agent Tool Category Isolation"
-      
-      (it "preserves the custom category to avoid being purged by upstream read-only presets"
-        (let ((mock-tool (gptel-make-tool :name "my_custom_tool" 
-                                          :function #'ignore 
-                                          :category "macher-agent-calendar" 
-                                          :description "test" 
-                                          :args nil))
-              ;; Extract the clearing function from the upstream preset definition
-              (clear-fn (plist-get (plist-get macher--preset-clear-tools :tools) :function)))
-          
-          ;; The custom tool MUST maintain its distinct category boundary
-          (expect (gptel-tool-category mock-tool) :not :to-equal macher-tool-category)
-          
-          ;; It MUST survive the upstream framework's aggressive tool purge
-          (let ((filtered-tools (funcall clear-fn (list mock-tool))))
-            (expect (length filtered-tools) :to-equal 1)
-            (expect (gptel-tool-name (car filtered-tools)) :to-equal "my_custom_tool")))))
-    (describe "Virtual File System (VFS) Sandbox Isolation"
-      
-      (describe "macher-agent--vfs-apply-overlay"
-        
-        (it "reroutes virtual edits to the ephemeral sandbox, protecting the physical disk"
-          (let* ((workspace-root "/my/project/")
-                 (sandbox-dir "/tmp/sandbox-12345/")
-                 ;; Create a mock context representing a dirty workspace
-                 (mock-ws (cons 'agent workspace-root))
-                 (mock-ctx (macher--make-context :dirty-p t 
-                                                 :workspace mock-ws
-                                                 :contents '(("/my/project/src/main.rs" . ("orig" . "new content")))))
-                 (write-region-called-with nil))
-            
-            ;; Mock the context root provider (struct access)
-            (spy-on 'macher--workspace-root :and-return-value workspace-root)
-            
-            ;; Intercept the destructive write action
-            (spy-on 'write-region :and-call-fake 
-                    (lambda (start _end filename &rest _)
-                      (push (list start filename) write-region-called-with)))
-            
-            (macher-agent--vfs-apply-overlay mock-ctx sandbox-dir)
-            
-            ;; The orchestrator MUST execute a file write...
-            (expect 'write-region :to-have-been-called)
-            
-            ;; ...it MUST write the new virtual content...
-            (expect (caar write-region-called-with) :to-equal "new content")
-            
-            ;; ...and CRITICALLY, it MUST write it to the sandbox, NOT the physical /my/project/ path!
-            (expect (cadar write-region-called-with) :to-equal "/tmp/sandbox-12345/src/main.rs")))
+                    (describe "Macher-Agent Tool Category Isolation"
+                              
+                              (it "preserves the custom category to avoid being purged by upstream read-only presets"
+                                  (let ((mock-tool (gptel-make-tool :name "my_custom_tool" 
+                                                                    :function #'ignore 
+                                                                    :category "macher-agent-calendar" 
+                                                                    :description "test" 
+                                                                    :args nil))
+                                        ;; Extract the clearing function from the upstream preset definition
+                                        (clear-fn (plist-get (plist-get macher--preset-clear-tools :tools) :function)))
+                                    
+                                    ;; The custom tool MUST maintain its distinct category boundary
+                                    (expect (gptel-tool-category mock-tool) :not :to-equal macher-tool-category)
+                                    
+                                    ;; It MUST survive the upstream framework's aggressive tool purge
+                                    (let ((filtered-tools (funcall clear-fn (list mock-tool))))
+                                      (expect (length filtered-tools) :to-equal 1)
+                                      (expect (gptel-tool-name (car filtered-tools)) :to-equal "my_custom_tool")))))
+                    (describe "Virtual File System (VFS) Sandbox Isolation"
+                              
+                              (describe "macher-agent--vfs-apply-overlay"
+                                        
+                                        (it "reroutes virtual edits to the ephemeral sandbox, protecting the physical disk"
+                                            (let* ((workspace-root "/my/project/")
+                                                   (sandbox-dir "/tmp/sandbox-12345/")
+                                                   ;; Create a mock context representing a dirty workspace
+                                                   (mock-ws (cons 'agent workspace-root))
+                                                   (mock-ctx (macher--make-context :dirty-p t 
+                                                                                   :workspace mock-ws
+                                                                                   :contents '(("/my/project/src/main.rs" . ("orig" . "new content")))))
+                                                   (write-region-called-with nil))
+                                              
+                                              ;; Mock the context root provider (struct access)
+                                              (spy-on 'macher--workspace-root :and-return-value workspace-root)
+                                              
+                                              ;; Intercept the destructive write action
+                                              (spy-on 'write-region :and-call-fake 
+                                                      (lambda (start _end filename &rest _)
+                                                        (push (list start filename) write-region-called-with)))
+                                              
+                                              (macher-agent--vfs-apply-overlay mock-ctx sandbox-dir)
+                                              
+                                              ;; The orchestrator MUST execute a file write...
+                                              (expect 'write-region :to-have-been-called)
+                                              
+                                              ;; ...it MUST write the new virtual content...
+                                              (expect (caar write-region-called-with) :to-equal "new content")
+                                              
+                                              ;; ...and CRITICALLY, it MUST write it to the sandbox, NOT the physical /my/project/ path!
+                                              (expect (cadar write-region-called-with) :to-equal "/tmp/sandbox-12345/src/main.rs")))
 
-        (it "does not flush anything if the virtual memory is clean"
-          (let* ((mock-ctx (macher--make-context :dirty-p nil :contents nil)))
-            
-            (spy-on 'write-region)
-            
-            (macher-agent--vfs-apply-overlay mock-ctx "/tmp/sandbox-12345/")
-            
-            ;; Ensure no ghost files are created in the sandbox
-            (expect 'write-region :not :to-have-been-called))))
+                                        (it "does not flush anything if the virtual memory is clean"
+                                            (let* ((mock-ctx (macher--make-context :dirty-p nil :contents nil)))
+                                              
+                                              (spy-on 'write-region)
+                                              
+                                              (macher-agent--vfs-apply-overlay mock-ctx "/tmp/sandbox-12345/")
+                                              
+                                              ;; Ensure no ghost files are created in the sandbox
+                                              (expect 'write-region :not :to-have-been-called))))
 
-      (describe "VFS Strict Pipeline Execution"
-        (it "always executes the 3-step composition in exact order for every tool"
-          (let ((call-order nil))
-            (spy-on 'macher-agent--vfs-verify-clean-merge :and-call-fake (lambda (&rest _) (push 'merge call-order)))
-            (spy-on 'macher-agent--vfs-sync-baseline :and-call-fake (lambda (&rest _) (push 'sync call-order)))
-            (spy-on 'macher-agent--vfs-apply-overlay :and-call-fake (lambda (&rest _) (push 'overlay call-order)))
-            
-            ;; Execute a dummy tool
-            (let ((mock-context (macher--make-context :workspace nil :contents nil)))
-              (spy-on 'macher-agent-context-root :and-return-value "/my/project/")
-              (spy-on 'make-temp-file :and-return-value "/tmp/sandbox-12345/")
-              (spy-on 'delete-directory)
-              (spy-on 'shell-command-to-string :and-return-value "running")
-              
-              (macher-agent-with-strict-vfs-pipeline mock-context
-                                                     (shell-command-to-string "echo 'running'")))
-            
-            ;; 1. Assert they were all called
-            (expect 'macher-agent--vfs-verify-clean-merge :to-have-been-called)
-            (expect 'macher-agent--vfs-sync-baseline :to-have-been-called)
-            (expect 'macher-agent--vfs-apply-overlay :to-have-been-called)
-            
-            ;; 2. Assert exact execution order
-            (expect (reverse call-order) :to-equal '(merge sync overlay))))
-        
-        (it "does not mangle OS-level absolute sandbox paths during rsync"
-          ;; This specific test prevents the regression we just experienced
-          (spy-on 'macher-agent--build-rsync-cmd :and-return-value "echo dummy")
-          (spy-on 'delete-directory)
-          
-          (let ((mock-context (macher--make-context :workspace nil :contents nil)))
-            (spy-on 'macher-agent-context-root :and-return-value "/my/project/")
-            (macher-agent-with-strict-vfs-pipeline mock-context nil))
-          
-          ;; The destination argument to rsync MUST be an absolute path in /tmp or /var
-          (let ((rsync-dest-arg (nth 1 (spy-calls-args-for 'macher-agent--build-rsync-cmd 0))))
-            (expect (file-name-absolute-p rsync-dest-arg) :to-be t)))))
-    (describe "Interactive Commands & State (macher-agent-orchestration.el)"
-      (it "macher-agent-add-buffer-to-scope explicitly errors out if no existing session is found"
-        (let ((buf (generate-new-buffer "lazy-target")))
-          (let ((macher--fsm-latest nil)
-                (macher-agent--persistent-context nil))
-            (cl-letf (((symbol-function 'buffer-list) (lambda () nil)))
-              (expect (macher-agent-add-buffer-to-scope "lazy-target") :to-throw 'error)))
-          (kill-buffer buf)))
-      (it "macher-agent-add-subagent creates a buffer and tracks it globally"
-        (let* ((mock-workspace (make-macher-agent-workspace :project-root "/tmp/"))
-               (mock-context (macher-agent--make-vfs-context :workspace (cons 'agent mock-workspace) :contents nil)))
-          (spy-on 'macher-agent-current-context :and-return-value mock-context)
-          (let ((buf (macher-agent-add-subagent "test-worker" "/tmp/" nil mock-context)))
-            (expect (buffer-live-p buf) :to-be t)
-            (expect (assoc "test-worker" (macher-agent-workspace-active-subagents (macher-agent--get-context-workspace (macher-agent-current-context)))) :to-be-truthy)
-            (kill-buffer buf))))
+                              (describe "VFS Strict Pipeline Execution"
+                                        (it "always executes the 3-step composition in exact order for every tool"
+                                            (let ((call-order nil))
+                                              (spy-on 'macher-agent--vfs-verify-clean-merge :and-call-fake (lambda (&rest _) (push 'merge call-order)))
+                                              (spy-on 'macher-agent--vfs-sync-baseline :and-call-fake (lambda (&rest _) (push 'sync call-order)))
+                                              (spy-on 'macher-agent--vfs-apply-overlay :and-call-fake (lambda (&rest _) (push 'overlay call-order)))
+                                              
+                                              ;; Execute a dummy tool
+                                              (let ((mock-context (macher--make-context :workspace nil :contents nil)))
+                                                (spy-on 'macher-agent-context-root :and-return-value "/my/project/")
+                                                (spy-on 'make-temp-file :and-return-value "/tmp/sandbox-12345/")
+                                                (spy-on 'delete-directory)
+                                                (spy-on 'shell-command-to-string :and-return-value "running")
+                                                
+                                                (macher-agent-with-strict-vfs-pipeline mock-context
+                                                                                       (shell-command-to-string "echo 'running'")))
+                                              
+                                              ;; 1. Assert they were all called
+                                              (expect 'macher-agent--vfs-verify-clean-merge :to-have-been-called)
+                                              (expect 'macher-agent--vfs-sync-baseline :to-have-been-called)
+                                              (expect 'macher-agent--vfs-apply-overlay :to-have-been-called)
+                                              
+                                              ;; 2. Assert exact execution order
+                                              (expect (reverse call-order) :to-equal '(merge sync overlay))))
+                                        
+                                        (it "does not mangle OS-level absolute sandbox paths during rsync"
+                                            ;; This specific test prevents the regression we just experienced
+                                            (spy-on 'macher-agent--build-rsync-cmd :and-return-value "echo dummy")
+                                            (spy-on 'delete-directory)
+                                            
+                                            (let ((mock-context (macher--make-context :workspace nil :contents nil)))
+                                              (spy-on 'macher-agent-context-root :and-return-value "/my/project/")
+                                              (macher-agent-with-strict-vfs-pipeline mock-context nil))
+                                            
+                                            ;; The destination argument to rsync MUST be an absolute path in /tmp or /var
+                                            (let ((rsync-dest-arg (nth 1 (spy-calls-args-for 'macher-agent--build-rsync-cmd 0))))
+                                              (expect (file-name-absolute-p rsync-dest-arg) :to-be t)))))
+                    (describe "Interactive Commands & State (macher-agent-orchestration.el)"
+                              (it "macher-agent-add-buffer-to-scope explicitly errors out if no existing session is found"
+                                  (let ((buf (generate-new-buffer "lazy-target")))
+                                    (let ((macher--fsm-latest nil)
+                                          (macher-agent--persistent-context nil))
+                                      (cl-letf (((symbol-function 'buffer-list) (lambda () nil)))
+                                        (expect (macher-agent-add-buffer-to-scope "lazy-target") :to-throw 'error)))
+                                    (kill-buffer buf)))
+                              (it "macher-agent-add-subagent creates a buffer and tracks it globally"
+                                  (let* ((mock-workspace (make-macher-agent-workspace :project-root "/tmp/"))
+                                         (mock-context (macher-agent--make-vfs-context :workspace (cons 'agent mock-workspace) :contents nil)))
+                                    (spy-on 'macher-agent-current-context :and-return-value mock-context)
+                                    (let ((buf (macher-agent-add-subagent "test-worker" "/tmp/" nil mock-context)))
+                                      (expect (buffer-live-p buf) :to-be t)
+                                      (expect (assoc "test-worker" (macher-agent-workspace-active-subagents (macher-agent--get-context-workspace (macher-agent-current-context)))) :to-be-truthy)
+                                      (kill-buffer buf))))
 
-      (it "macher-agent-apply-virtual-buffers applies pending context edits to live Emacs buffers"
-        (let* ((buf (generate-new-buffer "live-target"))
-               (ctx (macher--make-context :contents (list (cons (buffer-name buf) (cons "old" "new text"))))))
-          (with-current-buffer buf (insert "old"))
-          
-          (spy-on 'macher-agent-current-context :and-return-value ctx)
-          (spy-on 'macher-agent--auto-sync-context)
-          
-          (macher-agent-apply-virtual-buffers)
-          
-          (with-current-buffer buf
-            (expect (buffer-string) :to-equal "new text"))
-          (kill-buffer buf)))
+                              (it "macher-agent-apply-virtual-buffers applies pending context edits to live Emacs buffers"
+                                  (let* ((buf (generate-new-buffer "live-target"))
+                                         (ctx (macher--make-context :contents (list (cons (buffer-name buf) (cons "old" "new text"))))))
+                                    (with-current-buffer buf (insert "old"))
+                                    
+                                    (spy-on 'macher-agent-current-context :and-return-value ctx)
+                                    (spy-on 'macher-agent--auto-sync-context)
+                                    
+                                    (macher-agent-apply-virtual-buffers)
+                                    
+                                    (with-current-buffer buf
+                                      (expect (buffer-string) :to-equal "new text"))
+                                    (kill-buffer buf)))
 
-      (it "clears persistent context and latest FSM upon user request"
-        (let ((buf (generate-new-buffer "active-session")))
-          (with-current-buffer buf
-            (setq-local macher-agent--persistent-context 'some-data)
-            (setq-local macher--fsm-latest 'some-fsm)
-            (macher-agent-clear-context)
-            (expect macher-agent--persistent-context :to-be nil)
-            (expect macher--fsm-latest :to-be nil))
-          (kill-buffer buf))))
+                              (it "clears persistent context and latest FSM upon user request"
+                                  (let ((buf (generate-new-buffer "active-session")))
+                                    (with-current-buffer buf
+                                      (setq-local macher-agent--persistent-context 'some-data)
+                                      (setq-local macher--fsm-latest 'some-fsm)
+                                      (macher-agent-clear-context)
+                                      (expect macher-agent--persistent-context :to-be nil)
+                                      (expect macher--fsm-latest :to-be nil))
+                                    (kill-buffer buf))))
 
-    (describe "Tool Signatures (Macro Contracts)"
-      (before-all
-        (macher-agent-make-tool mock-async-contract-tool
-                                "Mock async tool"
-                                :category "test"
-                                :args (list (list :name "arg1" :type 'string) (list :name "arg2" :type 'string))
-                                :command-fn (lambda (payload)
-                                              (make-macher-agent-tool-response :type 'lisp-result :payload (format "Async %s %s" (plist-get payload :arg1) (plist-get payload :arg2)))))
+                    (describe "Tool Signatures (Macro Contracts)"
+                              (before-all
+                               (macher-agent-make-tool mock-async-contract-tool
+                                                       "Mock async tool"
+                                                       :category "test"
+                                                       :args (list (list :name "arg1" :type 'string) (list :name "arg2" :type 'string))
+                                                       :command-fn (lambda (payload)
+                                                                     (make-macher-agent-tool-response :type 'lisp-result :payload (format "Async %s %s" (plist-get payload :arg1) (plist-get payload :arg2)))))
 
-        (macher-agent-make-tool mock-sync-contract-tool
-                                "Mock sync tool"
-                                :category "test"
-                                :args (list (list :name "arg1" :type 'string))
-                                :command-fn (lambda (payload)
-                                              (make-macher-agent-tool-response :type 'lisp-result :payload (format "Sync %s" (plist-get payload :arg1))))))
+                               (macher-agent-make-tool mock-sync-contract-tool
+                                                       "Mock sync tool"
+                                                       :category "test"
+                                                       :args (list (list :name "arg1" :type 'string))
+                                                       :command-fn (lambda (payload)
+                                                                     (make-macher-agent-tool-response :type 'lisp-result :payload (format "Sync %s" (plist-get payload :arg1))))))
 
-      (it "generates variadic signatures for async tools to safely absorb FSM contexts"
-        (let* ((tool-fn (gptel-tool-function mock-async-contract-tool))
-               (arity (func-arity tool-fn)))
-          ;; A variadic &rest signature always has a minimum of 0 and a maximum of 'many
-          (expect (car arity) :to-equal 0)
-          (expect (cdr arity) :to-equal 'many)))
+                              (it "generates variadic signatures for async tools to safely absorb FSM contexts"
+                                  (let* ((tool-fn (gptel-tool-function mock-async-contract-tool))
+                                         (arity (func-arity tool-fn)))
+                                    ;; A variadic &rest signature always has a minimum of 0 and a maximum of 'many
+                                    (expect (car arity) :to-equal 0)
+                                    (expect (cdr arity) :to-equal 'many)))
 
-      (it "generates variadic signatures for sync tools to safely absorb FSM contexts"
-        (let* ((tool-fn (gptel-tool-function mock-sync-contract-tool))
-               (arity (func-arity tool-fn)))
-          (expect (car arity) :to-equal 0)
-          (expect (cdr arity) :to-equal 'many))))
-    
-    (describe "Agent Skills (macher-agent-skills.el)"
-      (before-each
-        (spy-on 'macher-agent-current-context :and-return-value
-                (macher-agent--make-vfs-context :workspace (make-macher-agent-workspace :project-root "/mock/proj") :contents nil)))
-      (it "parses SKILL.md files correctly extracting frontmatter and markdown body"
-        (let* ((parsed (macher-agent-parse-skill-file "tests/fixtures/skills/global/SKILL.md")))
-          (expect (plist-get parsed :name) :to-equal "mock-skill")
-          (expect (plist-get parsed :name-sym) :to-equal 'mock-skill)
-          (expect (plist-get parsed :description) :to-equal "A mock skill for testing")
-          (expect (plist-get parsed :allowed-tools) :to-equal '("mock-tool-1" "mock-tool-2"))
-          (expect (plist-get parsed :body) :to-equal "This is the system prompt for the mock skill.\nIt spans multiple lines.")))
+                              (it "generates variadic signatures for sync tools to safely absorb FSM contexts"
+                                  (let* ((tool-fn (gptel-tool-function mock-sync-contract-tool))
+                                         (arity (func-arity tool-fn)))
+                                    (expect (car arity) :to-equal 0)
+                                    (expect (cdr arity) :to-equal 'many))))
+                    
+                    (describe "Agent Skills (macher-agent-skills.el)"
+                              (before-each
+                               (spy-on 'macher-agent-current-context :and-return-value
+                                       (macher-agent--make-vfs-context :workspace (make-macher-agent-workspace :project-root "/mock/proj") :contents nil)))
+                              (it "parses SKILL.md files correctly extracting frontmatter and markdown body"
+                                  (let* ((parsed (macher-agent-parse-skill-file "tests/fixtures/skills/global/SKILL.md")))
+                                    (expect (plist-get parsed :name) :to-equal "mock-skill")
+                                    (expect (plist-get parsed :name-sym) :to-equal 'mock-skill)
+                                    (expect (plist-get parsed :description) :to-equal "A mock skill for testing")
+                                    (expect (plist-get parsed :allowed-tools) :to-equal '("mock-tool-1" "mock-tool-2"))
+                                    (expect (plist-get parsed :body) :to-equal "This is the system prompt for the mock skill.\nIt spans multiple lines.")))
 
-      (it "resolves global skill tools by loading their script if not registered"
-        (spy-on 'file-exists-p :and-return-value t)
-        (spy-on 'insert-file-contents :and-call-fake (lambda (f) (insert "(setq mock-tool-load 'loaded-tool-object)")))
-        ;; Resolution test
-        (let ((resolved (macher-agent-resolve-tool "mock-tool-load" nil "tests/fixtures/skills/global/")))
-          (expect resolved :to-equal 'loaded-tool-object)))
+                              (it "resolves global skill tools by loading their script if not registered"
+                                  (spy-on 'file-exists-p :and-return-value t)
+                                  (spy-on 'insert-file-contents :and-call-fake (lambda (f) (insert "(setq mock-tool-load 'loaded-tool-object)")))
+                                  ;; Resolution test
+                                  (let ((resolved (macher-agent-resolve-tool "mock-tool-load" nil "tests/fixtures/skills/global/")))
+                                    (expect resolved :to-equal 'loaded-tool-object)))
 
-      (it "refuses to load workspace skill tools (security context)"
-        (let* ((mock-script-dir (expand-file-name "tests/fixtures/skills/workspace/scripts"))
-               (mock-script-path (expand-file-name "workspace-tool-1.el" mock-script-dir)))
-          ;; Setup mock script
-          (make-directory mock-script-dir t)
-          (with-temp-file mock-script-path
-            (insert "(setq workspace-tool-1 'workspace-loaded)"))
-          
-          ;; Test workspace parsing logic
-          (macher-agent--load-skill-from-path "tests/fixtures/skills/workspace/" "tests/fixtures/skills/workspace/SKILL.md" (macher-agent-current-context))
-          (let* ((workspace (macher-agent--get-context-workspace (macher-agent-current-context)))
-                 (skill-meta (alist-get 'workspace-skill (macher-agent-workspace-skills-alist workspace))))
-            (expect (plist-get skill-meta :context-dir) :to-be nil))
-          
-          ;; Resolution should fail to load because context-dir is nil,
-          ;; returning the raw string fallback instead of a loaded tool object.
-          (let ((resolved (macher-agent-resolve-tool "workspace-tool-1" nil nil)))
-            (expect resolved :to-equal "workspace-tool-1"))
-          
-          (delete-directory mock-script-dir t)))
+                              (it "refuses to load workspace skill tools (security context)"
+                                  (let* ((mock-script-dir (expand-file-name "tests/fixtures/skills/workspace/scripts"))
+                                         (mock-script-path (expand-file-name "workspace-tool-1.el" mock-script-dir)))
+                                    ;; Setup mock script
+                                    (make-directory mock-script-dir t)
+                                    (with-temp-file mock-script-path
+                                      (insert "(setq workspace-tool-1 'workspace-loaded)"))
+                                    
+                                    ;; Test workspace parsing logic
+                                    (macher-agent--load-skill-from-path "tests/fixtures/skills/workspace/" "tests/fixtures/skills/workspace/SKILL.md" (macher-agent-current-context))
+                                    (let* ((workspace (macher-agent--get-context-workspace (macher-agent-current-context)))
+                                           (skill-meta (alist-get 'workspace-skill (macher-agent-workspace-skills-alist workspace))))
+                                      (expect (plist-get skill-meta :context-dir) :to-be nil))
+                                    
+                                    ;; Resolution should fail to load because context-dir is nil,
+                                    ;; returning the raw string fallback instead of a loaded tool object.
+                                    (let ((resolved (macher-agent-resolve-tool "workspace-tool-1" nil nil)))
+                                      (expect resolved :to-equal "workspace-tool-1"))
+                                    
+                                    (delete-directory mock-script-dir t)))
 
-      (it "verifies tool resolution hierarchy (workspace shadows package tools)"
-        (let* ((pkg-dir (make-temp-file "macher-pkg" t))
-               (ws-dir (make-temp-file "macher-ws" t))
-               (pkg-scripts (expand-file-name "scripts" pkg-dir))
-               (ws-scripts (expand-file-name "scripts" ws-dir)))
-          (make-directory pkg-scripts t)
-          (make-directory ws-scripts t)
-          ;; Package provides tool-a and tool-b
-          (with-temp-file (expand-file-name "tool-a.el" pkg-scripts) (insert "(setq tool-a 'pkg-a)"))
-          (with-temp-file (expand-file-name "tool-b.el" pkg-scripts) (insert "(setq tool-b 'pkg-b)"))
-          ;; Workspace overrides tool-a
-          (with-temp-file (expand-file-name "tool-a.el" ws-scripts) (insert "(setq tool-a 'ws-a)"))
-          
-          ;; Clear registry
-          (let* ((ctx (macher-agent-current-context))
-                 (ws (macher-agent--get-context-workspace ctx)))
-            (clrhash (macher-agent-workspace-tools-registry ws)))
-          
-          ;; Resolve pkg first, then workspace shadows
-          (let* ((res-pkg-b (macher-agent-resolve-tool "tool-b" nil pkg-dir))
-                 (res-ws-a (macher-agent-resolve-tool "tool-a" nil ws-dir)))
-            (expect res-pkg-b :to-equal 'pkg-b)
-            (expect res-ws-a :to-equal 'ws-a))
-          
-          (delete-directory pkg-dir t)
-          (delete-directory ws-dir t)))
-      
-      (it "applies skill tools correctly into gptel-tools when selected"
-        (let ((gptel-tools nil)
-              (mock-tool-obj (if (fboundp 'gptel-make-tool)
-                                 (gptel-make-tool :name "the_tool" :function (lambda () nil) :description "A tool")
-                               'the-tool)))
-          (spy-on 'gptel-tool-p :and-return-value t)
-          (let* ((ctx (macher-agent-current-context))
-                 (ws (macher-agent--get-context-workspace ctx)))
-            (puthash "selected-tool" mock-tool-obj (macher-agent-workspace-tools-registry ws))
-            
-            (setf (alist-get 'test-preset (macher-agent-workspace-skills-alist ws))
-                  (list :description "test" :system "Directive body" :tools (list mock-tool-obj) :context-dir nil))
-            
-            (macher-agent--apply-preset 'test-preset)
-            
-            (expect gptel-tools :to-equal (list mock-tool-obj)))))
+                              (it "verifies tool resolution hierarchy (workspace shadows package tools)"
+                                  (let* ((pkg-dir (make-temp-file "macher-pkg" t))
+                                         (ws-dir (make-temp-file "macher-ws" t))
+                                         (pkg-scripts (expand-file-name "scripts" pkg-dir))
+                                         (ws-scripts (expand-file-name "scripts" ws-dir)))
+                                    (make-directory pkg-scripts t)
+                                    (make-directory ws-scripts t)
+                                    ;; Package provides tool-a and tool-b
+                                    (with-temp-file (expand-file-name "tool-a.el" pkg-scripts) (insert "(setq tool-a 'pkg-a)"))
+                                    (with-temp-file (expand-file-name "tool-b.el" pkg-scripts) (insert "(setq tool-b 'pkg-b)"))
+                                    ;; Workspace overrides tool-a
+                                    (with-temp-file (expand-file-name "tool-a.el" ws-scripts) (insert "(setq tool-a 'ws-a)"))
+                                    
+                                    ;; Clear registry
+                                    (let* ((ctx (macher-agent-current-context))
+                                           (ws (macher-agent--get-context-workspace ctx)))
+                                      (clrhash (macher-agent-workspace-tools-registry ws)))
+                                    
+                                    ;; Resolve pkg first, then workspace shadows
+                                    (let* ((res-pkg-b (macher-agent-resolve-tool "tool-b" nil pkg-dir))
+                                           (res-ws-a (macher-agent-resolve-tool "tool-a" nil ws-dir)))
+                                      (expect res-pkg-b :to-equal 'pkg-b)
+                                      (expect res-ws-a :to-equal 'ws-a))
+                                    
+                                    (delete-directory pkg-dir t)
+                                    (delete-directory ws-dir t)))
+                              
+                              (it "applies skill tools correctly into gptel-tools when selected"
+                                  (let* ((gptel-tools nil)
+                                         (gptel--known-presets nil)
+                                         (gptel-directives nil)
+                                         (mock-tool-obj (if (fboundp 'gptel-make-tool)
+                                                            (gptel-make-tool :name "the_tool" :function (lambda () nil) :description "A tool")
+                                                          'the-tool)))
+                                    (spy-on 'gptel-tool-p :and-return-value t)
+                                    (let* ((ctx (macher-agent-current-context))
+                                           (workspace (macher-agent--get-context-workspace ctx)))
+                                      (puthash "selected-tool" mock-tool-obj (macher-agent-workspace-tools-registry workspace))
+                                      
+                                      (setf (alist-get 'test-preset (macher-agent-workspace-skills-alist workspace))
+                                            (list :description "test" :system "Directive body" :tools (list mock-tool-obj) :context-dir nil))
+                                      
+                                      (with-temp-buffer
+                                        (let ((gptel--known-presets nil))
+                                          (macher-agent-initialize-skills ctx)
+                                          (let ((preset-def (buffer-local-value 'gptel--known-presets (current-buffer))))
+                                            (setq preset-def (alist-get 'test-preset preset-def))
+                                            (expect preset-def :not :to-be nil)
+                                            (expect (plist-get preset-def :tools) :to-equal '(:append ("the_tool")))))))))
 
-      (it "creates a preset when allowed-tools is provided"
-        (let* ((mock-dir (make-temp-file "macher-test-skills-preset" t))
-               (skill-dir (expand-file-name "test-skill" mock-dir)))
-          (make-directory skill-dir t)
-          (with-temp-file (expand-file-name "SKILL.md" skill-dir)
-            (insert "---\nname: my-preset\ndescription: test\nallowed-tools:\n  - some-tool\nmodel: gpt-4o\n---\nPreset body"))
-          (spy-on 'gptel-make-preset)
-          (spy-on 'macher-agent-resolve-tool :and-return-value 'mock-tool)
-          (let ((gptel-directives nil))
-            (macher-agent-api-register-skills-in-directory mock-dir)
-            (expect 'gptel-make-preset :to-have-been-called)
-            (let ((args (spy-calls-args-for 'gptel-make-preset 0)))
-              (expect (car args) :to-equal 'my-preset)
-              (expect (plist-get (cdr args) :system) :to-equal "Preset body")
-              (expect (plist-get (cdr args) :model) :to-equal 'gpt-4o))
-            (expect (alist-get 'my-preset gptel-directives) :to-equal "Preset body"))
-          (delete-directory mock-dir t)))
+                              (it "creates a preset when allowed-tools is provided"
+                                  (let* ((mock-dir (make-temp-file "macher-test-skills-preset" t))
+                                         (skill-dir (expand-file-name "test-skill" mock-dir)))
+                                    (make-directory skill-dir t)
+                                    (with-temp-file (expand-file-name "SKILL.md" skill-dir)
+                                      (insert "---\nname: my-preset\ndescription: test\nallowed-tools:\n  - some-tool\nmodel: gpt-4o\n---\nPreset body"))
+                                    (spy-on 'macher-agent-resolve-tool :and-return-value "some-tool")
+                                    (with-temp-buffer
+                                      (let ((gptel-directives nil)
+                                            (gptel--known-presets nil))
+                                        (macher-agent-initialize-skills nil mock-dir)
+                                        
+                                        (let ((preset-def (alist-get 'my-preset gptel--known-presets)))
+                                          (expect preset-def :not :to-be nil)
+                                          (expect (plist-get preset-def :system) :to-equal "Preset body")
+                                          (expect (plist-get preset-def :model) :to-equal 'gpt-4o)
+                                          (expect (plist-get preset-def :tools) :to-equal '(:append ("some-tool"))))
+                                        (delete-directory mock-dir t)))))
 
-      (it "injects directly into gptel-directives when allowed-tools is omitted"
-        (let* ((mock-dir (make-temp-file "macher-test-skills-directive" t))
-               (skill-dir (expand-file-name "test-skill" mock-dir)))
-          (make-directory skill-dir t)
-          (with-temp-file (expand-file-name "SKILL.md" skill-dir)
-            (insert "---\nname: my-directive\n---\nDirective body"))
-          (let ((gptel-directives nil))
-            (macher-agent-api-register-skills-in-directory mock-dir)
-            (expect (alist-get 'my-directive gptel-directives) :to-equal "Directive body"))
-          (delete-directory mock-dir t))))))
+                              (it "injects directly into gptel-directives when allowed-tools is omitted"
+                                  (let* ((mock-dir (make-temp-file "macher-test-skills-directive" t))
+                                         (skill-dir (expand-file-name "test-skill" mock-dir)))
+                                    (make-directory skill-dir t)
+                                    (with-temp-file (expand-file-name "SKILL.md" skill-dir)
+                                      (insert "---\nname: my-directive\n---\nDirective body"))
+                                    (with-temp-buffer
+                                      (let ((gptel-directives nil)
+                                            (gptel--known-presets nil))
+                                        (macher-agent-initialize-skills nil mock-dir)
+                                        (expect (alist-get 'my-directive gptel-directives) :to-equal "Directive body")
+                                        (let ((preset-def (alist-get 'my-directive gptel--known-presets)))
+                                          (expect preset-def :not :to-be nil)
+                                          (expect (plist-get preset-def :system) :to-equal "Directive body"))
+                                        (delete-directory mock-dir t))))))))
 
 (provide 'macher-agent-test)


### PR DESCRIPTION
Concurrent agent executions previously suffered from global tool and preset bleeding. Additionally, delegate runs crashed due to an arity mismatch.

- Remove global preset registration: Bind gptel--known-presets and gptel-directives strictly via buffer-local values. Rely on gptel's native :append specification for dynamic tool unioning.
- Fix JIT reloading: Prioritise VFS memory in tool resolution rather than unconditionally returning cached instances.
- Fix delegate crashes: Rewrite preset transformation advice to use variadic arguments (&rest args). Safely extract fsm for standard chat buffer lookups, and pad zero-arity delegate calls with nil tp trap stringp exceptions.
- Fix gptel-restore: Add :before advice in the gptel bridge to run macher-agent-initialize-skills to populate buffer-local presets before gptel validates restored state.
- Fix tool initialisation: Add strict struct validation in macher-agent-initialize-skills to prevent gptel-tool-name crashes on raw string imports.