### PR TITLE
fix: reaper, async exec and patch gen

### DIFF
--- a/demo/demo-macher-agent.el
+++ b/demo/demo-macher-agent.el
@@ -42,7 +42,7 @@ SPEED is the delay between keystrokes (default 0.04 seconds)."
   (sit-for 1.0) 
 
   ;; Simulate the user typing the objective
-  (demo-macher-agent--type "@macher-agent-plan spawn two sub-agents. Delegate the task 'What is the capital of France?' to the first, and 'What is the capital of Spain?' to the second concurrently. Show both responses.")
+  (demo-macher-agent--type "@macher-agent-plan first spawn two sub-agents and then delegate the task 'What is the capital of France?' to the first, and 'What is the capital of Spain?' to the second concurrently. Show both responses.")
 
   ;; Pause briefly, then fire the request to the LLM
   (sit-for 0.5)

--- a/macher-agent-gptel-bridge.el
+++ b/macher-agent-gptel-bridge.el
@@ -153,6 +153,12 @@
 (defun macher-agent--gptel-restore-advice (orig-fun &rest args)
   "Bypass `gptel--restore-state' unless explicitly allowed."
   (when macher-agent--allow-gptel-restore
+    (let* ((proj (and (fboundp 'project-current) (project-current nil)))
+           (current-root (or (and proj (fboundp 'project-root) (project-root proj))
+                             (and (fboundp 'vc-root-dir) (vc-root-dir))
+                             default-directory)))
+      (when (and current-root (fboundp 'macher-agent--init-workspace-state))
+        (macher-agent--init-workspace-state current-root)))
     (let ((ctx (when (fboundp 'macher-agent-current-context)
                  (macher-agent-current-context))))
       (when ctx
@@ -207,13 +213,37 @@ Also aligns `gptel-backend` with `gptel-model` if the model belongs to a differe
 
 (advice-add 'gptel--apply-preset :after #'macher-agent--after-apply-preset-advice)
 
-(defun macher-agent--tolerate-dead-buffer-sentinel (orig-fn proc event &rest args)
-  "Prevent gptel's sentinel from crashing when a sub-agent buffer is abruptly reaped."
-  (let ((buf (process-buffer proc)))
-    (if (and buf (buffer-live-p buf))
-        (apply orig-fn proc event args)
-      (message "Macher-Agent: Suppressed gptel sentinel for reaped sub-agent."))))
+(defun macher-agent--tolerate-and-reap-sentinel (orig-fn proc event &rest args)
+  "Run gptel's sentinel safely and reap sub-agents only when explicitly flagged."
+  (let* ((internal-buf (process-buffer proc))
+         (fsm (car (alist-get proc gptel--request-alist)))
+         (proc-info (when fsm (gptel-fsm-info fsm)))
+         
+         ;; Extract the agent buffer via gptel's tracking keys
+         (agent-buf (when proc-info
+                      (or (plist-get proc-info :buffer)
+                          (let ((pos (plist-get proc-info :position)))
+                            (when (markerp pos) (marker-buffer pos)))))))
 
-(advice-add 'gptel-curl--sentinel :around #'macher-agent--tolerate-dead-buffer-sentinel)
+    ;; 1. Always run the original sentinel so gptel can process tool loops / callbacks
+    (condition-case err
+        (apply orig-fn proc event args)
+      ((error quit) nil))
+
+    ;; 2. Only reap if the buffer is live AND the flag is explicitly t
+    (when (and agent-buf (buffer-live-p agent-buf))
+      (let ((ready-to-reap (condition-case nil
+                               (buffer-local-value 'macher-agent--ready-to-reap agent-buf)
+                             (void-variable nil))))
+        (if (eq ready-to-reap t)
+            (progn
+              (message "Macher-Agent: Explicit flag detected. Reaping %s now." agent-buf)
+              (macher-agent--reap-buffer agent-buf))
+          ;; Do nothing if the flag is nil or void (e.g. during intermediate tool calls)
+          (message "Macher-Agent: Deferred reaping for %s (flag is %S)" 
+                   (buffer-name agent-buf) 
+                   (if (equal ready-to-reap nil) "nil" "unbound")))))))
+
+(advice-add 'gptel-curl--sentinel :around #'macher-agent--tolerate-and-reap-sentinel)
 
 (provide 'macher-agent-gptel-bridge)

--- a/macher-agent-macher-bridge.el
+++ b/macher-agent-macher-bridge.el
@@ -112,9 +112,64 @@
     ;; 2. PHYSICAL FILES
     ;; Always run this pass even if empty, so the core package naturally generates 
     ;; its native "No changes were made" UI if needed.
-    (let ((p-ctx (macher-agent--make-vfs-context :workspace ws :contents physical-contents)))
+    (let ((p-ctx (macher-agent--make-vfs-context :workspace ws :contents physical-contents))
+          (shadow-descriptors nil))
       (setf (macher-context-prompt p-ctx) (macher-context-prompt context))
-      (funcall orig-fn p-ctx fsm))))
+      
+      ;; Identify physical files that have active open back buffers visiting them,
+      ;; and construct the shadow descriptors to temporarily redirect buffer operations.
+      (dolist (entry physical-contents)
+        (let* ((file-path (car entry))
+               (new-content (cdr (cdr entry)))
+               (orig-buf (or (get-file-buffer file-path)
+                             (find-buffer-visiting file-path))))
+          (when (and orig-buf (buffer-live-p orig-buf))
+            (push (list :original-buffer orig-buf
+                        :original-file-name (buffer-file-name orig-buf)
+                        :original-buffer-name (buffer-name orig-buf)
+                        :file-path file-path
+                        :new-content new-content
+                        :shadow-buffer nil)
+                  shadow-descriptors))))
+      
+      (unwind-protect
+          (progn
+            ;; Temporarily rename and detach the user's real buffers, and create shadow buffers
+            (dolist (desc shadow-descriptors)
+              (let* ((orig-buf (plist-get desc :original-buffer))
+                     (orig-name (plist-get desc :original-buffer-name))
+                     (file-path (plist-get desc :file-path))
+                     (new-content (plist-get desc :new-content))
+                     (temp-name (generate-new-buffer-name (format " *macher-hidden-%s*" orig-name))))
+                (with-current-buffer orig-buf
+                  (rename-buffer temp-name t)
+                  (setq buffer-file-name nil))
+                
+                (let ((shadow-buf (get-buffer-create orig-name)))
+                  (with-current-buffer shadow-buf
+                    (setq buffer-file-name file-path)
+                    (setq buffer-file-truename (file-truename file-path))
+                    (insert new-content)
+                    (set-buffer-modified-p nil))
+                  (plist-put desc :shadow-buffer shadow-buf))))
+            
+            ;; Execute the core patch builder
+            (funcall orig-fn p-ctx fsm))
+        
+        ;; Cleanup phase: destroy shadow buffers and perfectly restore original buffers
+        (dolist (desc shadow-descriptors)
+          (let ((shadow (plist-get desc :shadow-buffer))
+                (orig-buf (plist-get desc :original-buffer))
+                (orig-name (plist-get desc :original-buffer-name))
+                (orig-file (plist-get desc :original-file-name)))
+            (when (and shadow (buffer-live-p shadow))
+              (with-current-buffer shadow
+                (setq buffer-file-name nil))
+              (kill-buffer shadow))
+            (when (and orig-buf (buffer-live-p orig-buf))
+              (with-current-buffer orig-buf
+                (setq buffer-file-name orig-file)
+                (rename-buffer orig-name t)))))))))
 
 (advice-add 'macher--build-patch :around #'macher-agent--override-build-patch)
 

--- a/macher-agent-orchestration.el
+++ b/macher-agent-orchestration.el
@@ -145,9 +145,12 @@
                           (setq-local macher-agent--ready-to-reap t)))
                       
                       (funcall callback res)
-                      
-                      (when (buffer-live-p buf)
-                        (run-at-time 0.1 nil #'macher-agent--reap-buffer buf))))
+
+                      ;; removed -- use already in place sentinel
+                      ;;(when (buffer-live-p buf)
+                      ;; (run-at-time 0.1 nil #'macher-agent--reap-buffer buf))
+                      )
+                    )
 
         (let* ((raw-str (when preset (if (symbolp preset) (symbol-name preset) preset)))
                (clean-sym (when raw-str (intern (replace-regexp-in-string "^@+" "" raw-str))))

--- a/macher-agent.el
+++ b/macher-agent.el
@@ -1,7 +1,7 @@
 ;;; macher-agent.el --- Sandboxed, Language-Agnostic AI Workflows -*- lexical-binding: t; -*-
 
 ;; Author: Elijah Charles
-;; Version: 0.8.0.2
+;; Version: 0.8.0.3
 ;; Package-Requires: ((emacs "29.1") (gptel "0.9.0") (macher "0.5.0"))
 ;; Keywords: convenience, gptel, llm, macher
 ;; URL: https://github.com/elij/macher-agent

--- a/skills/scripts/execute_subagents.el
+++ b/skills/scripts/execute_subagents.el
@@ -1,32 +1,32 @@
 (macher-agent-make-tool macher-agent-execute-subagents-tool
-                        "Execute multiple sub-agents asynchronously or synchronously."
+                        "Execute tasks across multiple sub-agents in parallel in a fire-and-forget, non-blocking manner."
                         :category "orchestrate"
-                        :args '((:name "buffer_names" :type array :items (:type string))
-                                (:name "blocking" :type boolean :optional t))
-                        :command-fn (lambda (payload context root)
-                                      (let ((buffer_names (plist-get payload :buffer_names))
-                                            (blocking (plist-get payload :blocking)))
-                                        (let ((tasks (cl-loop for buf in (append buffer_names nil)
-                                                              collect (list :buffer_name buf :instructions "" :preset nil))))
-                                          (if (and blocking (not (eq blocking :json-false)))
-                                              (make-macher-agent-tool-response :type 'delegate :payload (vconcat tasks))
-                                            (progn
-                                              (cl-loop for buf in (append buffer_names nil) do
-                                                       (let* ((actual-name (macher-agent--resolve-buffer-name buf))
-                                                              (target-buffer (get-buffer actual-name)))
-                                                         (when (buffer-live-p target-buffer)
-                                                           (with-current-buffer target-buffer
-                                                             (gptel-send)))))
-                                              (make-macher-agent-tool-response :type 'lisp-result :payload (format "Triggered %d sub-agents asynchronously." (length buffer_names))))))))
-                        :success-fn (lambda (results)
-                                      (if (stringp results)
-                                          results
-                                        (let ((output (list "Execution complete. Outputs:\n")))
-                                          (cl-loop for res across (if (vectorp results) results (vconcat results))
-                                                   do (push (format "=== %s ===\n%s\n" 
-                                                                    (plist-get res :buffer_name)
-                                                                    (if (eq (plist-get res :status) 'success)
-                                                                        (plist-get res :data)
-                                                                      (plist-get res :error)))
-                                                            output))
-                                          (string-join (nreverse output) "\n")))))
+                        :args '((:name "tasks" :type array :description "An array of task objects to execute in parallel in the background."
+                                       :items (:type object
+                                                     :properties (:buffer_name (:type string)
+                                                                               :instructions (:type string)
+                                                                               :preset (:type string))
+                                                     :required ["buffer_name" "instructions"])))
+                        :command-fn (lambda (payload)
+                                      (let* ((raw-tasks (plist-get payload :tasks))
+                                             (normalized-tasks
+                                              (cl-loop for task-obj in (append raw-tasks nil)
+                                                       collect (list :buffer_name (or (plist-get task-obj :buffer_name)
+                                                                                      (alist-get 'buffer_name task-obj)
+                                                                                      (alist-get "buffer_name" task-obj nil nil #'equal))
+                                                                     :instructions (or (plist-get task-obj :instructions)
+                                                                                       (alist-get 'instructions task-obj)
+                                                                                       (alist-get "instructions" task-obj nil nil #'equal))
+                                                                     :preset       (or (plist-get task-obj :preset)
+                                                                                       (alist-get 'preset task-obj)
+                                                                                       (alist-get "preset" task-obj nil nil #'equal)
+                                                                                       "macher-agent-worker")))))
+                                        (dolist (task normalized-tasks)
+                                          (macher-agent-spawn-task task (lambda (res) 
+                                                                          (message "Background subagent %s task execution completed with status: %s"
+                                                                                   (plist-get res :buffer_name)
+                                                                                   (plist-get res :status)))))
+                                        (make-macher-agent-tool-response
+                                         :type 'lisp-result
+                                         :payload (format "SUCCESS: Dispatched %d sub-agents in the background. They are executing independently and asynchronously. Your current buffer remains unblocked and you can proceed with other tasks immediately."
+                                                          (length normalized-tasks))))))

--- a/tests/macher-agent-core-test.el
+++ b/tests/macher-agent-core-test.el
@@ -63,6 +63,7 @@
                           (puthash "/mock/proj/overlay.el" "VFS Overlay Content" (macher-agent-workspace-vfs-buffers workspace))
                           
                           (let ((written-to-sandbox nil))
+                            (spy-on 'file-in-directory-p :and-return-value t)
                             (spy-on 'write-region :and-call-fake
                                     (lambda (start end filename &rest _args)
                                       (when (string-suffix-p "overlay.el" filename)
@@ -145,7 +146,67 @@
                             (expect (car (car orig-called-with)) :to-equal '("/mock/proj/disk-file.el" "old" . "new"))
                             
                             ;; The virtual pass (executed first, so it sits in the second slot)
-                            (expect (car (cadr orig-called-with)) :to-equal '("*scratch*" "old" . "new"))))))
+                            (expect (car (cadr orig-called-with)) :to-equal '("*scratch*" "old" . "new")))))
+
+                    (it "creates temporary shadow buffers and renames open physical back buffers during build-patch"
+                        (let* ((workspace (make-macher-agent-workspace :project-root "/mock/proj/"))
+                               (file-path "/mock/proj/live-file.el")
+                               (context (macher--make-context :workspace (cons 'project "/mock/proj/")
+                                                              :contents `((,file-path . ("old content" . "new virtual content")))))
+                               (fsm 'mock-fsm)
+                               ;; Create an actual live buffer visiting that file
+                               (live-buf (get-buffer-create "live-file.el")))
+                          
+                          (with-current-buffer live-buf
+                            (setq buffer-file-name file-path)
+                            (setq buffer-file-truename (file-truename file-path))
+                            (insert "old content")
+                            (set-buffer-modified-p nil))
+                          
+                          (spy-on 'macher-agent-current-context :and-return-value context)
+                          (spy-on 'gptel-fsm-info :and-return-value (list :macher-agent-session (make-macher-agent-session :workspace workspace)))
+                          (setf (macher-context-dirty-p context) t)
+                          
+                          ;; Spy on macher--get-buffer to prevent real buffer rendering of the patch itself
+                          (spy-on 'macher--get-buffer :and-return-value (list (get-buffer-create "*patch*")))
+                          
+                          (let ((shadow-buffer-verified nil)
+                                (original-buffer-hidden nil))
+                            
+                            (macher-agent--override-build-patch 
+                             (lambda (_ctx _fsm)
+                               ;; Inside orig-fn:
+                               ;; 1. The original buffer should be renamed and file-visiting should be nil
+                               (expect (buffer-file-name live-buf) :to-be nil)
+                               (expect (buffer-name live-buf) :not :to-equal "live-file.el")
+                               (setq original-buffer-hidden t)
+                               
+                               ;; 2. A shadow buffer should exist with name "live-file.el" and visit file-path
+                               (let ((shadow (get-buffer "live-file.el")))
+                                 (expect shadow :not :to-be nil)
+                                 (when shadow
+                                   (expect (buffer-file-name shadow) :to-equal file-path)
+                                   (with-current-buffer shadow
+                                     (expect (buffer-string) :to-equal "new virtual content"))
+                                   (setq shadow-buffer-verified t))))
+                             context fsm)
+                            
+                            ;; After orig-fn, everything must be perfectly restored
+                            (expect original-buffer-hidden :to-be t)
+                            (expect shadow-buffer-verified :to-be t)
+                            
+                            ;; 3. Shadow buffer must be killed and original buffer must be restored
+                            (expect (get-buffer "live-file.el") :to-be live-buf)
+                            
+                            ;; 4. Original buffer must be restored
+                            (expect (buffer-name live-buf) :to-equal "live-file.el")
+                            (expect (buffer-file-name live-buf) :to-equal file-path))
+                          
+                          ;; Clean up the live-buf
+                          (when (buffer-live-p live-buf)
+                            (with-current-buffer live-buf
+                              (setq buffer-file-name nil))
+                            (kill-buffer live-buf)))))
 
           (describe "5. Sandbox Security & Path Traversal (Jailbreaks)"
                     

--- a/tests/macher-agent-integration-test.el
+++ b/tests/macher-agent-integration-test.el
@@ -11,6 +11,15 @@
 (put 'macher-agent--is-subagent 'permanent-local t)
 (put 'macher-agent--ready-to-reap 'permanent-local t)
 
+(defun macher-agent--reap-buffers-on-idle ()
+  "Reap all buffers that are subagents and marked ready-to-reap."
+  (dolist (buf (buffer-list))
+    (when (buffer-live-p buf)
+      (with-current-buffer buf
+        (when (and (bound-and-true-p macher-agent--is-subagent)
+                   (bound-and-true-p macher-agent--ready-to-reap))
+          (macher-agent--reap-buffer buf))))))
+
 (describe "Macher-Agent Orchestration Integration"
           (before-each
            (setq macher-agent--garbage-queue nil)

--- a/tests/macher-agent-test.el
+++ b/tests/macher-agent-test.el
@@ -255,7 +255,46 @@
                                            (processed-tool (car processed-tools)))
                                       
                                       ;; PROOF: The tool has been wrapped and is now expecting the context
-                                      (expect (funcall (gptel-tool-function processed-tool)) :to-equal 'injected-context)))))
+                                      (expect (funcall (gptel-tool-function processed-tool)) :to-equal 'injected-context))))
+
+                              (it "correctly initialises and binds the context during session restoration, preventing buffer-list fallback leakage"
+                                  (let* ((other-buf (generate-new-buffer "other-chat-buffer"))
+                                         (restore-buf (generate-new-buffer "restored-chat-buffer"))
+                                         (other-dir "/mock/proj/other")
+                                         (restore-dir "/mock/proj/restore")
+                                         (macher-agent--allow-gptel-restore t)
+                                         (orig-called nil)
+                                         (orig-fun (lambda (&rest _args) (setq orig-called t))))
+                                    
+                                    (unwind-protect
+                                        (progn
+                                          ;; 1. Set up the other buffer to simulate an active workspace that could be leaked
+                                          (with-current-buffer other-buf
+                                            (setq-local default-directory other-dir)
+                                            (macher-agent--init-workspace-state other-dir))
+                                          
+                                          ;; 2. Set up the restored buffer with its correct default-directory
+                                          (with-current-buffer restore-buf
+                                            (setq-local default-directory restore-dir)
+                                            
+                                            ;; Verify that prior to restore advice, persistent-context is nil
+                                            (expect (bound-and-true-p macher-agent--persistent-context) :to-be nil)
+                                            
+                                            ;; Execute the restore advice
+                                            (macher-agent--gptel-restore-advice orig-fun)
+                                            
+                                            ;; Verify the original restore function was called
+                                            (expect orig-called :to-be t)
+                                            
+                                            ;; Verify that the correct workspace context was created and bound
+                                            (let ((local-ctx (bound-and-true-p macher-agent--persistent-context)))
+                                              (expect local-ctx :not :to-be nil)
+                                              (let ((workspace (macher-agent--get-context-workspace local-ctx)))
+                                                (expect (macher-agent--get-workspace-root workspace) :to-equal (expand-file-name restore-dir))))))
+                                      
+                                      ;; Clean up temp buffers
+                                      (when (buffer-live-p other-buf) (kill-buffer other-buf))
+                                      (when (buffer-live-p restore-buf) (kill-buffer restore-buf))))))
                     (describe "Sandbox Execution (macher-agent-vfs-client.el)"
                               (describe "read_media_in_workspace"
                                         (it "errors if gptel-track-media is nil"
@@ -384,6 +423,9 @@
                                                                                    :contents '(("/my/project/src/main.rs" . ("orig" . "new content")))))
                                                    (write-region-called-with nil))
                                               
+                                              ;; Spy on file-in-directory-p to allow mock/non-existent sandbox directories
+                                              (spy-on 'file-in-directory-p :and-return-value t)
+
                                               ;; Mock the context root provider (struct access)
                                               (spy-on 'macher--workspace-root :and-return-value workspace-root)
                                               


### PR DESCRIPTION
Implemented reaper based on tool call ending rather than timer fixed execution behaviour and path resolution after gptel-restore-state Added work around for patch generation with open buffers