### PR TITLE
fix: resolve erroneous vfs invalidation

### DIFF
--- a/macher-agent-macher-bridge.el
+++ b/macher-agent-macher-bridge.el
@@ -188,25 +188,38 @@
         (when (fboundp 'macher-agent--set-context-shadow-buffers)
           (macher-agent--set-context-shadow-buffers p-ctx shadow-descriptors))
 
-        (funcall orig-fn p-ctx fsm)
+        ;; --- THE FIX BEGINS HERE ---
         
-        (run-at-time "3 sec" nil
-                     (lambda (descs)
-                       (dolist (desc descs)
-                         (let ((shadow (plist-get desc :shadow-buffer))
-                               (orig-buf (plist-get desc :original-buffer))
-                               (orig-name (plist-get desc :original-buffer-name))
-                               (orig-file (plist-get desc :original-file-name)))
-                           (when (and shadow (buffer-live-p shadow))
-                             (with-current-buffer shadow
-                               (set-buffer-modified-p nil) 
-                               (setq buffer-file-name nil))
-                             (kill-buffer shadow))
-                           (when (and orig-buf (buffer-live-p orig-buf))
-                             (with-current-buffer orig-buf
-                               (setq buffer-file-name orig-file)
-                               (rename-buffer orig-name t))))))
-                     shadow-descriptors)))))
+        ;; 1. Pause the VFS auto-sync to prevent it from reading the shadow buffers
+        (setq macher-agent--pause-auto-sync t)
+        
+        ;; 2. Create a self-removing cleanup closure attached to the upstream ready hook
+        (let ((cleanup-fn nil))
+          (setq cleanup-fn
+                (lambda ()
+                  (unwind-protect
+                      (dolist (desc shadow-descriptors)
+                        (let ((shadow (plist-get desc :shadow-buffer))
+                              (orig-buf (plist-get desc :original-buffer))
+                              (orig-name (plist-get desc :original-buffer-name))
+                              (orig-file (plist-get desc :original-file-name)))
+                          (when (and shadow (buffer-live-p shadow))
+                            (with-current-buffer shadow
+                              (set-buffer-modified-p nil) 
+                              (setq buffer-file-name nil))
+                            (kill-buffer shadow))
+                          (when (and orig-buf (buffer-live-p orig-buf))
+                            (with-current-buffer orig-buf
+                              (setq buffer-file-name orig-file)
+                              (rename-buffer orig-name t)))))
+                    ;; Always restore the sync flag and remove the hook, even if an error occurs
+                    (setq macher-agent--pause-auto-sync nil)
+                    (remove-hook 'macher-patch-ready-hook cleanup-fn))))
+          
+          (add-hook 'macher-patch-ready-hook cleanup-fn))
+
+        ;; 3. Trigger the asynchronous upstream builder
+        (funcall orig-fn p-ctx fsm)))))
 
 (advice-add 'macher--build-patch :around #'macher-agent--override-build-patch)
 

--- a/macher-agent-vfs-client.el
+++ b/macher-agent-vfs-client.el
@@ -515,8 +515,13 @@ Uniformly applies security and path normalisation checks."
             t))
       nil)))
 
+(defvar macher-agent--pause-auto-sync nil
+  "When non-nil, `macher-agent--auto-sync-context` will silently abort.
+Used to prevent race conditions during shadow-buffer patch generation.")
+
 (defun macher-agent--auto-sync-context (ctx &rest _args)
-  (when ctx
+  "Synchronise the active context with the physical disk, unless paused."
+  (when (and ctx (not macher-agent--pause-auto-sync))
     (let ((contents (macher-agent--get-context-contents ctx))
           (synced nil))
       (dolist (entry contents)

--- a/macher-agent.el
+++ b/macher-agent.el
@@ -1,7 +1,7 @@
 ;;; macher-agent.el --- Sandboxed, Language-Agnostic AI Workflows -*- lexical-binding: t; -*-
 
 ;; Author: Elijah Charles
-;; Version: 0.8.0.7
+;; Version: 0.8.0.8
 ;; Package-Requires: ((emacs "29.1") (gptel "0.9.0") (macher "0.5.0"))
 ;; Keywords: convenience, gptel, llm, macher
 ;; URL: https://github.com/elij/macher-agent
@@ -9,8 +9,8 @@
 
 ;;; Commentary:
 ;;
-;; Macher-Agent provides sandboxed, language-agnostic AI workflows
-;; using sub-agent orchestration and virtual 3-way file merging.
+;; An Emacs-native LLM agent harness featuring isolated sandboxing,
+;; asynchronous sub-agent orchestration, and fail-fast sync file merging. 
 ;;
 
 ;;; Code:

--- a/tests/macher-agent-core-test.el
+++ b/tests/macher-agent-core-test.el
@@ -14,6 +14,8 @@
 (cl-defstruct mock-gptel-fsm info state)
 
 (describe "Macher-Agent Core Behaviours"
+          (after-each
+           (setq macher-agent--pause-auto-sync nil))
           
           (describe "1. VFS and Optimistic Concurrency"
                     (it "asserts that a VFS write is rejected if the underlying file has drifted"
@@ -134,7 +136,9 @@
                           (let ((orig-called-with nil))
                             ;; Execute our bridge interceptor, mocking the core function to capture the splits
                             (macher-agent--override-build-patch 
-                             (lambda (ctx _fsm) (push (macher-context-contents ctx) orig-called-with))
+                             (lambda (ctx _fsm) 
+                               (push (macher-context-contents ctx) orig-called-with)
+                               (run-hooks 'macher-patch-ready-hook))
                              context fsm)
                             
                             ;; Assert that the core patch builder was called twice
@@ -192,7 +196,8 @@
                                    (with-current-buffer shadow
                                      (expect (buffer-string) :to-equal "new virtual content")
                                      (expect default-directory :to-equal (file-name-directory (expand-file-name file-path))))
-                                   (setq shadow-buffer-verified t))))
+                                   (setq shadow-buffer-verified t))
+                                 (run-hooks 'macher-patch-ready-hook)))
                              context fsm)
                             
                             ;; After orig-fn, everything must be perfectly restored


### PR DESCRIPTION
upstream patch build was clearing vfs.
added flag so vfs only cleared interactively or
through applying patches