### PR TITLE
chore: native upstream alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Please review the [wiki](https://www.google.com/search?q=https://github.com/elij
 
 ## Emacs-native LLM orchestration
 
+* The harness allows agents to solve problems in a sanbdox uninterrupted prior to providing a unified diff. In contrast to per tool permission dialogues.
 * The harness provides strict sandboxing, allowing you to run untrusted code or commands inside secure, ephemeral directory and Emacs Lisp environments.
 * Non-blocking multiplexing lets you orchestrate multiple sub-agents and operations concurrently without leaving your Emacs session or resorting to a terminal interface.
 * Because there are no non-elisp dependencies, the core harness is built purely in Emacs Lisp, making every hook, FSM transition, and tool call completely hackable and customisable.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -149,7 +149,7 @@ Developers MUST expect the following upstream data structures when intercepting 
 
 1. **`gptel-fsm` (Finite State Machine):** An upstream struct tracking the LLM request.  `macher-agent` MUST interact with it primarily via `(gptel-fsm-info fsm)`, which returns a Lisp property list (plist).
 * *Expected keys:* `:buffer`, `:backend`, `:data`, `:tools`.
-* *Injected keys:* `macher-agent` MUST safely inject `:macher-agent-session` and `:macher--context` into this plist.
+* *Injected keys:* `macher-agent` MUST safely inject `:macher-agent-session` and `:macher-agent-context` into this plist.
 
 2. **`gptel-tool`:** An upstream struct.  `macher-agent` relies on `gptel-tool-name` (returns a string or symbol) and `gptel-tool-function` (returns a Lisp closure).
 - The extraction and comparison MUST be wrapped in a canonical tool name handler:
@@ -174,10 +174,10 @@ The system MUST intercept `gptel`'s private networking and stream insertion func
 
 #### 6.2.2 Media and prompt injection
 
-* **Target:** `gptel--fsm-transition`
-* **Interception:** `advice-add :around` (`#'macher-agent--inject-media-fsm-advice`)
-* **Inputs received:** `(machine &optional new-state &rest args)`
-* **Behaviour:** Before transitioning to the WAIT state, the advice MUST extract the session via `(plist-get (gptel-fsm-info machine) :macher-agent-session)`.  If `pending-media` is present in the session, the advice MUST invoke `gptel--inject-media` and `gptel--inject-prompt`, then set `pending-media` strictly to nil.
+* **Target:** `gptel-prompt-transform-functions`
+* **Processor:** `#'macher-agent-sync-prompt-transformer`
+* **Inputs received:** `(async-fn fsm)`
+* **Behaviour:** During the prompt construction phase before network transmission, if `pending-media` is present in the active context, `macher-agent-sync-prompt-transformer` invokes `macher-agent-inject-pending-media`, injecting media into the payload via `gptel--inject-media` and `gptel--inject-prompt`, then clearing `pending-media`.
 
 #### 6.2.3 Base64 virtual file system override
 
@@ -217,21 +217,19 @@ Because `macher` relies on Emacs physical buffers and `macher-agent` uses pure-m
 #### 6.3.2 Context singleton intercept
 
 * **Target:** `macher--make-context`
-* **Interception:** `advice-add :around` (`#'macher-agent--override-make-context`)
-* **Inputs received:** `(&rest kwargs)` expecting plists: `:prompt`, `:process-request-function`, `:contents`, `:workspace`.
-* **Behaviour:** The upstream function creates a new `macher-context` struct.  The advice MUST block this creation and instead return the buffer-local `macher-agent--persistent-context` singleton.
-* **Data mutation:** The advice MUST parse `:contents` (where upstream provides a list of `(path orig-string . new-string)`) and hydrate them into the VFS entries via `macher-agent--update-context-file` before returning the singleton.
+* **Interception:** `advice-add :around` (`#'macher-agent--around-make-context`)
+* **Inputs received:** `(orig-fun &rest args)`
+* **Behaviour:** Intercepts `macher--make-context` to check whether `macher-agent--persistent-context` is bound locally. If bound and non-nil, it returns the persistent context structure, ensuring the native setup transformer reuses the existing context state rather than instantiating a blank context.
 
 #### 6.3.3 The double-pass patch generation
 
-* **Target:** `macher--build-patch`
-* **Interception:** `advice-add :around` (`#'macher-agent--override-build-patch`)
-* **Inputs received:** `(context &optional fsm)`
+* **Target:** `macher-process-request-function`
+* **Processor:** `#'macher-agent-process-request`
+* **Inputs received:** `(&optional status context fsm)`
 * **Behaviour and invariants:**
-  1. **Partitioning:** The advice MUST partition active workspace edits into standard physical and virtual contexts using `macher-agent-prepare-upstream-payloads`.
-  2. **Delegate formatting:** Instead of using shadow buffers, the advice delegates formatting back to the native `macher` engine by calling the original patch building function with each partitioned context.
+  1. **Partitioning:** The function MUST partition active workspace edits into standard physical and virtual contexts using `macher-agent-prepare-upstream-payloads`.
+  2. **Delegate formatting:** Instead of using shadow buffers, the function delegates formatting back to the native `macher` engine by calling `macher--build-patch` with each partitioned context.
   3. **Unique suffixes:** It extracts the original workspace buffer using `macher-patch-buffer` and dynamically applies a physical (`*macher-physical-patch...*`) or virtual (`*macher-virtual-patch...*`) buffer name prefix while retaining unique workspace suffixes.
-  4. **Avoid automatic sync race conditions:** During the build process, the advice prevents automatic synchronisation from executing concurrently by using the `macher-agent--pause-auto-sync` sentinel or managing individual pass separation.
 
 ---
 
@@ -240,7 +238,7 @@ Because `macher` relies on Emacs physical buffers and `macher-agent` uses pure-m
 ### 7.1 The gptel bridge
 
 1. **Nil response protection**: `gptel--insert-response` is advised to gracefully handle empty (nil) streaming chunks without throwing Emacs type errors.
-2. **Media injection**: `gptel--fsm-transition` is advised.  If the VFS session contains `pending-media` (where the tool itself performs the read and base64 serialisation), the raw base64 data is injected directly into the LLM request FSM immediately before transitioning to the WAIT state.
+2. **Media injection**: Handled during prompt construction via `gptel-prompt-transform-functions` in `macher-agent-sync-prompt-transformer`. If the context contains `pending-media`, raw base64 data is injected directly into the prompt payload before transmission and cleared from the queue.
 3. **Base64 override**: The native `gptel--base64-encode` is intercepted to check the VFS first.  If the file exists in the agent's memory, it encodes the virtual string instead of reading the physical disk.
 
 ### 7.2 The macher bridge for patch generation
@@ -249,5 +247,5 @@ Because `macher` expects separate updates and `macher-agent` uses both physical 
 
 1. **Context intercept:** `macher--make-context` is intercepted to return the global `macher-agent--persistent-context` singleton, ensuring the patch generator sees all virtual and physical edits in the active workspace.
 2. **Context splitting:** The context preprocessor `macher-agent-prepare-upstream-payloads` partitions active workspace edits into standard physical and virtual contexts.
-3. **Double-pass routing:** `macher-agent--override-build-patch` delegates the formatting of each partitioned context back to the native `macher` engine.
+3. **Double-pass routing:** `macher-agent-process-request` delegates the formatting of each partitioned context back to the native `macher` engine via `macher--build-patch`.
 4. **Buffer separation:** Unique, isolated buffers are produced for physical and virtual updates with preserved workspace hashes and suffixes.

--- a/macher-agent-api.el
+++ b/macher-agent-api.el
@@ -128,7 +128,7 @@ CONTEXT is the active context structure.
 
 Return the project root path string, or nil."
   (when-let* ((workspace (when context (macher-agent--get-context-workspace context))))
-    (when workspace (macher-agent-root workspace))))
+    (macher-agent-workspace-project-root workspace)))
 
 (defun macher-normalise-preset-name (preset)
   "Remove leading character symbols and convert PRESET to a uniform symbol.
@@ -262,7 +262,9 @@ Return a property list containing skill properties."
                  until vfs-content
                  do (let ((entry (cl-find cand contents :key #'car :test #'equal)))
                       (when entry
-                        (setq vfs-content (if (consp (cdr entry)) (cddr entry) (cdr entry))))))))
+                        (setq vfs-content (if
+                                              (consp (cdr entry))
+                                              (cddr entry) (cdr entry))))))))
     (when (and (not vfs-content) resolved-ctx)
       (let* ((workspace (macher-agent--get-context-workspace resolved-ctx))
              (vfs-buffers (when workspace (macher-agent-workspace-vfs-buffers workspace))))
@@ -273,7 +275,9 @@ Return a property list containing skill properties."
     (when (and (not vfs-content) resolved-ctx)
       (cl-loop for cand in candidates
                until vfs-content
-               do (setq vfs-content (ignore-errors (macher-agent--read-context-file resolved-ctx cand)))))
+               do (setq vfs-content
+                        (ignore-errors
+                          (macher-agent--read-context-file resolved-ctx cand)))))
     (with-temp-buffer
       (let ((org-inhibit-startup t))
         (setq default-directory (file-name-directory abs-file))
@@ -295,7 +299,8 @@ Return a property list containing skill properties."
           (when-let* (((re-search-forward "^---\n" nil t))
                       (start (point))
                       ((re-search-forward "^---\n" nil t))
-                      (frontmatter (buffer-substring-no-properties start (match-beginning 0))))
+                      (frontmatter (buffer-substring-no-properties start
+                                                                   (match-beginning 0))))
             (setq fm-hash (macher-agent--parse-frontmatter frontmatter)))
 
           (setq body (string-trim (buffer-substring-no-properties (point) (point-max))))
@@ -323,7 +328,8 @@ Return t if secure, otherwise nil."
 
 (defun macher-agent--parse-safe-forms (content &optional validation-cb)
   "Parse CONTENT and return a list of trusted forms.
-If VALIDATION-CB is provided, it is called on each form; if it returns nil, an error is signaled.
+If VALIDATION-CB is provided, it is called on each form; if it returns nil, an error is \
+signaled.
 
 CONTENT is the string block to parse.
 VALIDATION-CB is an optional validation function.
@@ -357,7 +363,8 @@ Return the cached tool object, or TOOL-NAME if evaluation fails."
                                                       (lambda (f)
                                                         (if (macher-agent--secure-ast-p f)
                                                             t
-                                                          (error "SECURITY WARNING: Tool attempts to evaluate top-level definition: %s" (car f))))))
+                                                          (error "SECURITY WARNING: Tool \
+attempts to evaluate top-level definition: %s" (car f))))))
                (val (progn
                       (let ((res nil))
                         (dolist (form forms res)
@@ -408,10 +415,13 @@ Return non-nil if managed, otherwise nil."
 
 ARGS represents the list of event arguments passed by the hook."
   (let* ((path (cl-find-if #'stringp args))
-         (context (or (cl-find-if (lambda (x) (and x (not (stringp x)) (fboundp 'macher-context-p) (macher-context-p x))) args)
-                      (bound-and-true-p macher-agent--persistent-context)))
+         (context (or
+                   (cl-find-if
+                    (lambda (x) (and x (not (stringp x))
+                                     (fboundp 'macher-context-p) (macher-context-p x))) args)
+                   (bound-and-true-p macher-agent--persistent-context)))
          (workspace (when context (macher-agent--get-context-workspace context))))
-    
+
     (when (and path (string-match "scripts/\\([^/]+\\)\\.el$" path))
       (let* ((tool-name (match-string 1 path))
              (registry (if workspace
@@ -429,15 +439,18 @@ ARGS represents the list of event arguments passed by the hook."
                (or (null path)
                    (string-match-p "skills/" path)
                    (string-match-p "SKILL\\.md$" path)))
-      (let ((skills-dir (expand-file-name "skills" (macher-agent-workspace-project-root workspace))))
+      (let ((skills-dir (expand-file-name "skills"
+                                          (macher-agent-workspace-project-root workspace))))
         (macher-agent-initialize-skills context skills-dir)))
 
-    (when (and path (fboundp 'macher-agent--is-managed-path-p) (macher-agent--is-managed-path-p path))
+    (when (and path (fboundp 'macher-agent--is-managed-path-p)
+               (macher-agent--is-managed-path-p path))
       nil)))
 
 (add-hook 'macher-agent-context-mutated-hook #'macher-agent--mutation-dispatcher)
 
-(defun macher-agent--locate-tool-source (tool-name context dir-context script-paths workspace)
+(defun macher-agent--locate-tool-source
+    (tool-name context dir-context script-paths workspace)
   "Locate the tool source content for TOOL-NAME.
 
 TOOL-NAME is the string name of the tool.
@@ -449,7 +462,9 @@ WORKSPACE is the active workspace struct.
 Return the tool source content string, or nil."
   (if-let* ((context context)
             (vfs-content
-             (let* ((vfs-path (when dir-context (expand-file-name (format "scripts/%s.el" tool-name) dir-context)))
+             (let* ((vfs-path (when dir-context
+                                (expand-file-name (format "scripts/%s.el" tool-name)
+                                                  dir-context)))
                     (workspace-root (macher-context-workspace-root context))
                     (rel-to-workspace (when (and workspace-root vfs-path)
                                         (file-relative-name vfs-path workspace-root)))
@@ -459,11 +474,15 @@ Return the tool source content string, or nil."
                     (visiting-buf-name (when visiting-buf (buffer-name visiting-buf)))
                     (std-name (format "scripts/%s.el" tool-name))
                     (base-name (format "%s.el" tool-name))
-                    (candidates (delq nil (list vfs-path rel-to-workspace rel-to-dir visiting-buf-name std-name base-name)))
+                    (candidates (delq nil
+                                      (list vfs-path rel-to-workspace
+                                            rel-to-dir visiting-buf-name std-name base-name)))
                     (found-content nil))
                (cl-loop for cand in candidates
                         until found-content
-                        do (setq found-content (ignore-errors (macher-agent--read-context-file context cand))))
+                        do (setq found-content
+                                 (ignore-errors (macher-agent--read-context-file
+                                                 context cand))))
                found-content)))
       vfs-content
     (let ((disk-content nil))
@@ -488,7 +507,9 @@ Return a list of validated trusted forms, or nil."
                                       (lambda (f)
                                         (if (macher-agent--secure-ast-p f)
                                             t
-                                          (message "Macher-Agent SECURITY WARNING: Skipped tool '%s' because it attempts to evaluate top-level definition: %s" tool-name (car f))
+                                          (message "Macher-Agent SECURITY WARNING: \
+Skipped tool '%s' because it attempts to evaluate top-level definition: %s"
+                                                   tool-name (car f))
                                           nil)))
     (error
      (message "Macher-Agent: Failed to parse tool %s - %s" tool-name err)
@@ -516,47 +537,57 @@ Return the evaluated tool struct, or nil."
        (setq captured-tool nil)))
     captured-tool))
 
-(defun macher-agent-resolve-tool (tool-name context dir-context)
-  "Retrieve TOOL-NAME from workspace registry or load from VFS/disk, deferring native tools.
+(defun macher-agent-resolve-tool (tool-name tools-registry &optional dir-context context)
+  "Retrieve TOOL-NAME from TOOLS-REGISTRY or load from VFS/disk, deferring native tools.
 
 TOOL-NAME is the name of the tool (string or symbol).
-CONTEXT is the active context structure.
+TOOLS-REGISTRY is the hash-table tools registry (or nil to resolve from context/global).
 DIR-CONTEXT is the active directory context string.
+CONTEXT is the active context structure.
 
 Return the resolved tool object, or TOOL-NAME if unresolved."
-  (let* ((workspace (when context (macher-agent--get-context-workspace context)))
-         (registry (if workspace (macher-agent-workspace-tools-registry workspace) macher-agent-tools-registry))
+  (let* ((registry (or tools-registry
+                       (when context
+                         (let ((ws (macher-agent--get-context-workspace context)))
+                           (when ws (macher-agent-workspace-tools-registry ws))))
+                       macher-agent-tools-registry))
          (canonical-name (macher-agent-canonical-tool-name tool-name))
-         (cached (and canonical-name (gethash canonical-name registry)))
-         (script-paths (when canonical-name
-                         (delq nil (list
-                                    (when dir-context (expand-file-name (format "scripts/%s.el" canonical-name) dir-context))
-                                    (expand-file-name (format "scripts/%s.el" canonical-name) (or (bound-and-true-p macher-agent--bundled-skills-dir) macher-agent-bundled-skills-directory))))))
-         (loaded-tool nil))
-
+         (cached (and canonical-name (gethash canonical-name registry))))
     (if cached
-        (setq loaded-tool cached)
-      (when canonical-name
-        (let ((content-to-eval (macher-agent--locate-tool-source canonical-name context dir-context script-paths workspace)))
-          (when content-to-eval
-            (let ((trusted-forms (macher-agent--parse-and-validate-tool-ast content-to-eval canonical-name)))
-              (when trusted-forms
-                (setq loaded-tool (macher-agent--evaluate-trusted-tool-ast trusted-forms canonical-name))))))))
+        cached
+      (let ((workspace (when context (macher-agent--get-context-workspace context)))
+            (script-paths (when canonical-name
+                            (delq nil (list
+                                       (when dir-context
+                                         (expand-file-name (format "scripts/%s.el"
+                                                                   canonical-name)
+                                                           dir-context))
+                                       (expand-file-name (format "scripts/%s.el"
+                                                                 canonical-name)
+                                                         (or
+                                                          (bound-and-true-p macher-agent--bundled-skills-dir) macher-agent-bundled-skills-directory))))))
+            (loaded-tool nil))
+        (when canonical-name
+          (let ((content-to-eval (macher-agent--locate-tool-source canonical-name context dir-context script-paths workspace)))
+            (when content-to-eval
+              (let ((trusted-forms (macher-agent--parse-and-validate-tool-ast content-to-eval canonical-name)))
+                (when trusted-forms
+                  (setq loaded-tool (macher-agent--evaluate-trusted-tool-ast trusted-forms canonical-name)))))))
 
-    (unless loaded-tool
-      (let* ((tool-sym (if (symbolp tool-name) tool-name (intern-soft tool-name)))
-             (sym-val (when (and tool-sym (boundp tool-sym)) (symbol-value tool-sym))))
-        (if (and sym-val (macher-tool-valid-p sym-val))
-            (setq loaded-tool sym-val)
-          (when canonical-name
-            (setq loaded-tool
-                  (ignore-errors
-                    (gptel-get-tool canonical-name)))))))
+        (unless loaded-tool
+          (let* ((tool-sym (if (symbolp tool-name) tool-name (intern-soft tool-name)))
+                 (sym-val (when (and tool-sym (boundp tool-sym)) (symbol-value tool-sym))))
+            (if (and sym-val (macher-tool-valid-p sym-val))
+                (setq loaded-tool sym-val)
+              (when canonical-name
+                (setq loaded-tool
+                      (ignore-errors
+                        (gptel-get-tool canonical-name)))))))
 
-    (when loaded-tool
-      (macher-agent--cache-tool loaded-tool registry))
+        (when loaded-tool
+          (macher-agent--cache-tool loaded-tool registry))
 
-    (or loaded-tool tool-name)))
+        (or loaded-tool tool-name)))))
 
 (defun macher-agent--load-scripts-from-dir (skills-dir context)
   "Load script tools from the scripts subdirectory of SKILLS-DIR.
@@ -567,10 +598,13 @@ CONTEXT is the active context structure.
 Return nil."
   (let ((scripts-dir (expand-file-name "scripts" skills-dir)))
     (when (file-directory-p scripts-dir)
-      (dolist (script (directory-files scripts-dir t "\\.el$"))
-        (let* ((base (file-name-base script))
-               (tool (macher-agent-resolve-tool base context skills-dir)))
-          (ignore tool))))))
+      (let* ((workspace (when context (macher-agent--get-context-workspace context)))
+             (registry (if workspace
+                           (macher-agent-workspace-tools-registry workspace) macher-agent-tools-registry)))
+        (dolist (script (directory-files scripts-dir t "\\.el$"))
+          (let* ((base (file-name-base script))
+                 (tool (macher-agent-resolve-tool base registry skills-dir context)))
+            (ignore tool)))))))
 
 (defun macher-agent--load-skill-from-path (path &optional context)
   "Load a skill from PATH and register it natively with gptel.
@@ -604,9 +638,12 @@ Return nil."
           (let* ((alist (if workspace
                             (macher-agent-workspace-skills-alist workspace)
                           macher-agent-global-skills-alist))
+                 (registry (if workspace
+                               (macher-agent-workspace-tools-registry workspace)
+                             macher-agent-tools-registry))
                  (resolved-tools (when tool-names
                                    (delq nil (mapcar (lambda (tname)
-                                                       (macher-agent-resolve-tool tname context skill-base-dir))
+                                                       (macher-agent-resolve-tool tname registry skill-base-dir context))
                                                      tool-names)))))
             (setf (alist-get sym alist)
                   (list :system body :description desc :model (when model (intern model)) :tools resolved-tools :exclusive exclusive))
@@ -705,13 +742,16 @@ Return nil."
                for tool-names = (mapcar #'macher-agent-canonical-tool-name tools)
                do (when system-prompt
                     (setf (alist-get sym gptel-directives) system-prompt)
-                    (let ((preset-spec (list :description (or desc (format "Agent Profile: %s" sym))
+                    (let ((preset-spec (list :description (or desc (format "Agent \
+Profile: %s" sym))
                                              :system system-prompt)))
-                      (when exclusive (setq preset-spec (plist-put preset-spec :exclusive t)))
+                      (when exclusive
+                        (setq preset-spec (plist-put preset-spec :exclusive t)))
                       (when model (setq preset-spec (plist-put preset-spec :model model)))
                       (when tool-names
                         (setq preset-spec (plist-put preset-spec :tools
-                                                     (if exclusive tool-names `(:append ,tool-names)))))
+                                                     (if exclusive
+                                                         tool-names `(:append ,tool-names)))))
                       (setf (alist-get sym gptel--known-presets) preset-spec))))))
 
   (when (fboundp 'gptel--setup-directive-menu)
@@ -753,8 +793,10 @@ ITEM is the tool identifier (string, symbol, or struct).
 
 Return a list of resolved gptel-tool structs, or nil."
   (let* ((ctx (ignore-errors (macher-agent-resolve-context)))
+         (ws (when ctx (macher-agent--get-context-workspace ctx)))
+         (registry (if ws (macher-agent-workspace-tools-registry ws) macher-agent-tools-registry))
          (skills-dir (when ctx (macher-agent-context-root ctx)))
-         (resolved (macher-agent-resolve-tool item ctx skills-dir)))
+         (resolved (macher-agent-resolve-tool item registry skills-dir ctx)))
     (if (and resolved (macher-tool-valid-p resolved))
         (list resolved)
       (let ((native (macher-agent--find-native-tool item)))

--- a/macher-agent-gptel-bridge.el
+++ b/macher-agent-gptel-bridge.el
@@ -205,27 +205,23 @@ Return nil."
       (when (fboundp 'macher-agent--auto-sync-context)
         (macher-agent--auto-sync-context ctx))
       (when fsm
-        (let ((session (or (plist-get info :macher-agent-session)
-                           (let* ((ws (macher-agent--get-context-workspace ctx))
-                                  (proj-root (if ws (macher-agent-root ws) default-directory))
-                                  (agent-ws (make-macher-agent-workspace :project-root proj-root)))
-                             (make-macher-agent-session :id (buffer-name) :workspace agent-ws)))))
-          (setf (gptel-fsm-info fsm) (plist-put info :macher-agent-session session)))))))
+        (let* ((info (gptel-fsm-info fsm))
+               (has-ctx (plist-get info :macher-agent-context)))
+          (unless has-ctx
+            (setf (gptel-fsm-info fsm) (plist-put info :macher-agent-context ctx))))))))
 
 (defun macher-agent--inject-media-fsm-advice (orig-fun fsm &rest args)
   "Inject pending tool media into the FSM payload right before transitioning to WAIT.
 
 ORIG-FUN is the original transition function.
-FSM is the finite-state machine struct.
-ARGS represents the arguments passed to ORIG-FUN.
-
-Return the result of ORIG-FUN."
+FSM is the finite-state machine object.
+ARGS represents additional arguments passed to ORIG-FUN."
   (let* ((new-state (car args))
          (target-state (or new-state (ignore-errors (gptel--fsm-next fsm)))))
     (when (or (eq target-state 'WAIT) (null target-state))
       (let* ((info (macher-agent--extract-fsm-info fsm))
-             (session (plist-get info :macher-agent-session))
-             (pending (when session (macher-agent-session-pending-media session))))
+             (ctx (plist-get info :macher-agent-context))
+             (pending (when ctx (macher-agent--get-context-data ctx :pending-media))))
 
         (when pending
           (let* ((msg-plist (list :role "user"
@@ -241,7 +237,7 @@ Return the result of ORIG-FUN."
                                     (plist-get info :data)
                                     (car prompts)))
 
-            (setf (macher-agent-session-pending-media session) nil))))))
+            (macher-agent--set-context-data ctx :pending-media nil))))))
   (apply orig-fun fsm args))
 
 (advice-add 'gptel--fsm-transition :around #'macher-agent--inject-media-fsm-advice)
@@ -287,7 +283,7 @@ ARGS represents the arguments passed to ORIG-FUN.
 Return the result of ORIG-FUN."
   (when macher-agent--allow-gptel-restore
     (setq-local macher-agent--is-restored-session t)
-    (let ((current-root (macher-agent-root nil)))
+    (let ((current-root (macher-agent-root default-directory)))
       (when (and current-root (fboundp 'macher-agent--init-workspace-state))
         (macher-agent--init-workspace-state current-root)))
     (let ((ctx (when (fboundp 'macher-agent-resolve-context)
@@ -323,13 +319,11 @@ Return a cons cell (BACKEND . MODEL-FORMAT) if found, otherwise nil."
   "Dynamically bound to the active FSM during tool execution hooks.")
 
 (defun macher-agent--bind-active-fsm-advice (orig-fn fsm &rest args)
-  "Capture the current FSM dynamically so tool validators do not rely on lagging state variables.
+  "Capture FSM dynamically so tool validators do not rely on lagging state variables.
 
 ORIG-FN is the original function being advised.
-FSM is the active finite-state machine.
-ARGS represents the arguments passed to ORIG-FN.
-
-Return the result of ORIG-FN."
+FSM is the active finite-state machine object.
+ARGS represents additional arguments passed to ORIG-FN."
   (let ((macher-agent--active-fsm fsm))
     (apply orig-fn fsm args)))
 
@@ -337,30 +331,22 @@ Return the result of ORIG-FN."
 (advice-add 'gptel--handle-tool-use :around #'macher-agent--bind-active-fsm-advice)
 (advice-add 'gptel--handle-post-tool :around #'macher-agent--bind-active-fsm-advice)
 
-(defun macher-agent--enforce-tool-scope (tool &rest _args)
+(defun macher-agent--enforce-tool-scope (tool &optional fsm &rest _args)
   "Enforce that TOOL is explicitly within the authorised scope.
 If not, block execution to prevent hallucinated or globally-leaked tools.
 
-To robustly validate the tool across execution boundaries (including
-asynchronous callbacks and temporary buffer switches), the function
-retrieves the active finite state machine (FSM) or fallback references
-and compares the incoming tool against the authorised toolset.
-
-It reads the tool names exclusively from the finite state machine snapshot,
-ignoring buffer-local variables to avoid race conditions.
-
 TOOL is the tool object or name to be verified.
+FSM is the optional finite-state machine object.
 _ARGS represents unused arguments passed from the hook.
 
 Return a block list if the tool is out of scope, otherwise nil."
   (let* ((canonical-name (macher-agent-canonical-tool-name tool))
-         (fsm (or macher-agent--active-fsm
-                  (bound-and-true-p macher--fsm-latest)
-                  (bound-and-true-p gptel--fsm-last)))
-         (info (when fsm (gptel-fsm-info fsm)))
+         (fsm-obj (or macher-agent--active-fsm
+                      (bound-and-true-p macher--fsm-latest)
+                      (bound-and-true-p gptel--fsm-last)))
+         (info (when fsm-obj (gptel-fsm-info fsm-obj)))
          (fsm-tools (when info (plist-get info :tools)))
-         (authorised-names
-          (mapcar #'macher-agent-canonical-tool-name fsm-tools)))
+         (authorised-names (mapcar #'macher-agent-canonical-tool-name fsm-tools)))
     (unless (and canonical-name (member canonical-name authorised-names))
       (list :block (format "ERROR: Tool '%s' is out of scope. It was not provided to this sub-agent." (or canonical-name tool))))))
 
@@ -379,68 +365,6 @@ Return nil."
       (add-hook 'gptel-pre-tool-call-functions #'macher-agent--setup-tools-pre-hook nil t))))
 
 (add-hook 'gptel-mode-hook #'macher-agent-setup-gptel-buffer)
-
-(defun macher--transform-setup-tools (callback fsm)
-  "A gptel prompt transform to set up macher tools and behaviour.
-Modified for macher-agent.
-
-CALLBACK is the function to invoke next.
-FSM is the finite-state machine."
-  (let* ((prompt (buffer-string))
-         (process-request-function macher-process-request-function)
-         (context-or-t nil)
-         (get-context
-          (lambda ()
-            (unless context-or-t
-              (let* ((info (gptel-fsm-info fsm))
-                     (buffer (plist-get info :buffer)))
-                (when (plist-get info :macher--context)
-                  (error "Macher context already present on FSM during setup"))
-                (unless buffer
-                  (error "Trying to set up macher tools, but coudn't determine request buffer"))
-                (setq context-or-t
-                      (if (buffer-live-p buffer)
-                          (let ((agent-ctx (buffer-local-value 'macher-agent--persistent-context buffer)))
-                            (if agent-ctx
-                                (progn
-                                  (when (fboundp 'macher-context-prompt)
-                                    (setf (macher-context-prompt agent-ctx) prompt))
-                                  (when (fboundp 'macher-context-process-request-function)
-                                    (setf (macher-context-process-request-function agent-ctx) process-request-function))
-                                  (setq info (plist-put info :macher--context agent-ctx))
-                                  (setf (gptel-fsm-info fsm) info)
-                                  agent-ctx)
-                              (if-let* ((workspace (with-current-buffer buffer (macher-workspace buffer))))
-                                  (let ((context (macher--make-context :workspace workspace
-                                                                       :prompt prompt
-                                                                       :process-request-function process-request-function)))
-                                    (setq info (plist-put info :macher--context context))
-                                    (setf (gptel-fsm-info fsm) info)
-                                    (with-current-buffer buffer (setq macher--fsm-latest fsm))
-                                    context)
-                                t)))
-                        t))))
-            (if (eq context-or-t t) nil context-or-t)))
-         (init-handler-invoked nil)
-         (init-handler
-          (lambda (fsm)
-            (unless init-handler-invoked
-              (setq init-handler-invoked t)
-              (macher--setup-tools fsm get-context))))
-         (termination-handler
-          (lambda (fsm)
-            (when (and context-or-t (funcall get-context))
-              (let* ((ctx (funcall get-context))
-                     (info (gptel-fsm-info fsm))
-                     (buffer (plist-get info :buffer)))
-                (when (and buffer (buffer-live-p buffer) (fboundp 'macher-agent--capture-pending-edits))
-                  (macher-agent--capture-pending-edits ctx buffer))
-                (let ((protected-contents (copy-sequence (macher-agent--get-context-contents ctx))))
-                  (funcall process-request-function 'complete ctx fsm)
-                  (macher-agent--set-context-contents ctx protected-contents)))))))
-    (macher--add-transition-handler fsm init-handler)
-    (macher--add-termination-handler fsm termination-handler))
-  (funcall callback))
 
 (provide 'macher-agent-gptel-bridge)
 ;;; macher-agent-gptel-bridge.el ends here

--- a/macher-agent-gptel-tools.el
+++ b/macher-agent-gptel-tools.el
@@ -84,8 +84,7 @@ Return the resolved context structure, or nil."
       (when-let* (((boundp 'macher-agent--active-fsm))
                   (fsm macher-agent--active-fsm)
                   (info (macher-agent--extract-fsm-info fsm)))
-        (or (plist-get info :macher-agent-context)
-            (plist-get info :macher--context)))))
+        (plist-get info :macher-agent-context))))
 
 (defun macher-agent--format-directives (result-data)
   "Append pending system instructions to RESULT-DATA if any exist.
@@ -154,7 +153,7 @@ NAME-SYMBOL is the symbol naming the tool variable.
 DESCRIPTION is the string describing the tool's purpose.
 CATEGORY is the optional classification category of the tool.
 ARGS is the list of argument specifications for the tool.
-COMMAND-FN is the function running the tool logic.
+COMMAND-FN is the function running the tool logic. Must accept (PAYLOAD CONTEXT ROOT).
 SUCCESS-FN is the function processing success results.
 OUTPUT-FILTER-FN is the optional function filtering tool output."
   (declare (indent 2))
@@ -165,99 +164,70 @@ OUTPUT-FILTER-FN is the optional function filtering tool output."
        (setq ,name-symbol
              (gptel-make-tool
               :name ,name
-              :description ,description :category ,(or category "macher-agent") :args ,args :async t
+              :description ,description 
+              :category ,(or category "macher-agent") 
+              :args ,args 
+              :async t
               :function
-              (lambda (&rest all-args)
-                (let* ((first-arg (car all-args))
-                       (last-arg (car (last all-args)))
-                       (is-async-cb-first (and first-arg (functionp first-arg) (not (keywordp first-arg))))
-                       (is-async-cb-last (and last-arg (functionp last-arg) (not (keywordp last-arg))))
-                       (callback (cond (is-async-cb-first first-arg)
-                                       (is-async-cb-last last-arg)
-                                       (t nil)))
-                       (raw-payload (cond (is-async-cb-first (cdr all-args))
-                                          (is-async-cb-last (butlast all-args))
-                                          (t all-args)))
-                       (payload
-                        (if (and raw-payload (keywordp (car raw-payload)))
-                            raw-payload
-                          (let ((pl nil)
-                                (idx 0)
-                                (tool-args-spec ,args))
-                            (dolist (arg raw-payload)
-                              (when-let* ((spec (nth idx tool-args-spec))
-                                          (arg-name (plist-get spec :name))
-                                          (key-sym (intern (concat ":" (if (symbolp arg-name)
-                                                                           (symbol-name arg-name)
-                                                                         arg-name)))))
-                                (setq pl (plist-put pl key-sym arg)))
-                              (setq idx (1+ idx)))
-                            pl)))
+              (lambda (callback &rest tool-args)
+                ;; 1. gptel guarantees `callback` is ALWAYS arg 1 for async tools.
+                ;; 2. `tool-args` are ALWAYS positional, mapped perfectly to the `args` spec.
+                
+                ;; Zip the positional args into a plist deterministically
+                (let* ((payload (cl-loop for arg in tool-args
+                                         for spec in ,args
+                                         for arg-name = (plist-get spec :name)
+                                         for key = (intern (concat ":" (if (symbolp arg-name) 
+                                                                           (symbol-name arg-name) 
+                                                                         arg-name)))
+                                         append (list key arg)))
                        (context (or (ignore-errors (macher-agent-resolve-context))
                                     (bound-and-true-p macher-agent--persistent-context)))
                        (root (if context (macher-agent-context-root context) default-directory))
-                       (cmd-eval ,command-fn)
-                       (succ-eval ,success-fn)
-                       (filter-eval ,output-filter-fn)
                        (wrap-cb (macher-agent--wrap-callback callback)))
                   
-                  (let ((pre-ok t)
-                        (pre-err nil))
-                    (condition-case hook-err
-                        (unless (run-hook-with-args-until-failure 'macher-agent-pre-tool-use-hook ',name-symbol payload)
-                          (setq pre-ok nil))
-                      (error
-                       (setq pre-ok nil
-                             pre-err (error-message-string hook-err))))
-                    (if (not pre-ok)
-                        (let ((err-msg (if pre-err
-                                           (format "Execution blocked by error in macher-agent-pre-tool-use-hook: %s" pre-err)
-                                         "Execution blocked by macher-agent-pre-tool-use-hook")))
-                          (funcall wrap-cb (list :status 'error :error err-msg)))
-                      
-                      (let ((perm-ok t)
-                            (perm-err nil))
-                        (condition-case hook-err
-                            (unless (run-hook-with-args-until-failure 'macher-agent-permission-request-hook ',name-symbol payload)
-                              (setq perm-ok nil))
+                  ;; Run pre-flight hooks with support for aborting on nil or errors.
+                  (condition-case pre-err
+                      (if (and macher-agent-pre-tool-use-hook
+                               (not (run-hook-with-args-until-failure 'macher-agent-pre-tool-use-hook ',name-symbol payload)))
+                          (funcall wrap-cb (list :status 'error :error "Execution blocked by macher-agent-pre-tool-use-hook"))
+                        (condition-case perm-err
+                            (if (and macher-agent-permission-request-hook
+                                     (not (run-hook-with-args-until-failure 'macher-agent-permission-request-hook ',name-symbol payload)))
+                                (funcall wrap-cb (list :status 'error :error "Permission denied by macher-agent-permission-request-hook"))
+                              (condition-case err
+                                  (let* ((action (funcall ,command-fn payload context root)))
+                                    
+                                    (unless (macher-agent-tool-response-p action)
+                                      (setq action (make-macher-agent-lisp-result-response
+                                                    :payload (if (stringp action) action (format "%S" action)))))
+                                    
+                                    (let ((on-success
+                                           (lambda (res-obj)
+                                             (condition-case cb-err
+                                                 (let* ((raw-payload (if (macher-agent-tool-response-p res-obj)
+                                                                         (macher-agent-tool-response-payload res-obj)
+                                                                       res-obj))
+                                                        (success-data (if ,success-fn (funcall ,success-fn raw-payload) raw-payload))
+                                                        (final-data (if ,output-filter-fn (funcall ,output-filter-fn success-data) success-data)))
+                                                   
+                                                   (run-hook-with-args 'macher-agent-post-tool-use-hook ',name-symbol payload final-data)
+                                                   (funcall wrap-cb (list :status 'success :data final-data)))
+                                               (error
+                                                (run-hook-with-args 'macher-agent-post-tool-use-failure-hook ',name-symbol payload cb-err)
+                                                (funcall wrap-cb (list :status 'error :error (error-message-string cb-err))))))))
+                                      
+                                      (macher-agent-execute-response action context on-success wrap-cb)))
+                                (error
+                                 (run-hook-with-args 'macher-agent-post-tool-use-failure-hook ',name-symbol payload err)
+                                 (funcall wrap-cb (list :status 'error :error (error-message-string err))))))
                           (error
-                           (setq perm-ok nil
-                                 perm-err (error-message-string hook-err))))
-                        (if (not perm-ok)
-                            (let ((err-msg (if perm-err
-                                               (format "Permission denied by error in macher-agent-permission-request-hook: %s" perm-err)
-                                             "Permission denied by macher-agent-permission-request-hook")))
-                              (funcall wrap-cb (list :status 'error :error err-msg)))
-                          
-                          (condition-case err
-                              (let* ((action (let* ((arity (func-arity cmd-eval))
-                                                    (max-args (cdr arity)))
-                                               (if (or (eq max-args 'many) (>= max-args 3))
-                                                   (funcall cmd-eval payload context root)
-                                                 (funcall cmd-eval payload)))))
-                                (unless (macher-agent-tool-response-p action)
-                                  (setq action (make-macher-agent-lisp-result-response
-                                                :payload (if (stringp action) action (format "%S" action)))))
-                                (let ((on-success
-                                       (lambda (res-obj)
-                                         (condition-case cb-err
-                                             (let* ((raw-payload (if (macher-agent-tool-response-p res-obj)
-                                                                     (macher-agent-tool-response-payload res-obj)
-                                                                   res-obj))
-                                                    (success-data (if succ-eval (funcall succ-eval raw-payload) raw-payload))
-                                                    (final-data (if filter-eval (funcall filter-eval success-data) success-data)))
-                                               (run-hook-with-args 'macher-agent-post-tool-use-hook ',name-symbol payload final-data)
-                                               (funcall wrap-cb (list :status 'success :data final-data)))
-                                           (error
-                                            (run-hook-with-args 'macher-agent-post-tool-use-failure-hook ',name-symbol payload cb-err)
-                                            (funcall wrap-cb (list :status 'error :error (error-message-string cb-err))))))))
-                                  (macher-agent-execute-response action context on-success wrap-cb)))
-                            (error
-                             (run-hook-with-args 'macher-agent-post-tool-use-failure-hook ',name-symbol payload err)
-                             (funcall wrap-cb (list :status 'error :error (error-message-string err))))))))))))))))
+                           (funcall wrap-cb (list :status 'error :error (format "Execution blocked by error in macher-agent-permission-request-hook: %s" (error-message-string perm-err)))))))
+                    (error
+                     (funcall wrap-cb (list :status 'error :error (format "Execution blocked by error in macher-agent-pre-tool-use-hook: %s" (error-message-string pre-err)))))))))))))
 
 (cl-defmethod macher-agent-execute-response ((res macher-agent-process-response) context on-success on-error)
-  "Execute RES in a sandbox, then invoke ON-SUCCESS or ON-ERROR."
+  "Execute response RES within CONTEXT in a sandbox, then invoke ON-SUCCESS or ON-ERROR."
   (let ((payload (macher-agent-tool-response-payload res)))
     (if (stringp payload)
         (macher-agent--run-in-persistent-sandbox
@@ -283,7 +253,7 @@ OUTPUT-FILTER-FN is the optional function filtering tool output."
   (funcall on-success res))
 
 (cl-defmethod macher-agent-execute-response ((res macher-agent-lisp-result-response) _context on-success _on-error)
-  "Execute Lisp payload asynchronously in a dedicated buffer, then invoke ON-SUCCESS."
+  "Execute Lisp payload for response RES asynchronously, then invoke ON-SUCCESS."
   (macher-agent-execute-lisp-task
    (macher-agent-tool-response-payload res)
    (lambda (lisp-result)
@@ -415,8 +385,8 @@ Return the base64-encoded representation string."
                      (and (boundp 'macher--fsm-latest) (symbol-value 'macher--fsm-latest))
                      (and (boundp 'gptel--fsm-last) (symbol-value 'gptel--fsm-last))))
             (info (ignore-errors (gptel-fsm-info fsm)))
-            (session (plist-get info :macher-agent-session))
-            (pending (macher-agent-session-pending-media session))
+            (ctx (plist-get info :macher-agent-context))
+            (pending (when ctx (macher-agent--get-context-data ctx :pending-media)))
             ((cl-some (lambda (item) (string= file (car item))) pending)))
       file
     (if-let* ((ctx (ignore-errors (macher-agent-current-context)))

--- a/macher-agent-macher-bridge.el
+++ b/macher-agent-macher-bridge.el
@@ -20,7 +20,7 @@
 WS is the workspace object.
 
 Return the absolute path string."
-  (macher-agent-root ws))
+  (macher-agent-workspace-project-root ws))
 
 (defun macher-agent--get-workspace-name (ws)
   "Retrieve a human-readable name for WS.
@@ -73,65 +73,35 @@ Return the MD5 hash string."
 
 (advice-add 'macher--workspace-hash :override #'macher-agent--safe-workspace-hash)
 
-(defvar macher-agent--bypass-context-override nil
-  "Internal flag to prevent intercepting our own ephemeral diff contexts.")
+(defvar-local macher-agent--persistent-context nil)
 
-(defun macher-agent--override-make-context (orig-fn &rest kwargs)
-  "Intercept the upstream constructor to natively enforce the VFS singleton.
+(defun macher-agent--around-make-context (orig-fun &rest args)
+  "Intercept `macher--make-context` to return `macher-agent--persistent-context` if bound locally.
 
-ORIG-FN is the original constructor function.
-KWARGS represents keyword arguments passed to the constructor.
+ORIG-FUN is the original `macher--make-context` constructor function.
+ARGS represents keyword arguments passed to the constructor.
 
-Return the context struct."
+Return the persistent context if bound and non-nil, otherwise call ORIG-FUN."
   (let ((persistent-ctx (bound-and-true-p macher-agent--persistent-context)))
-    (if (and persistent-ctx (not macher-agent--bypass-context-override))
+    (if persistent-ctx
         (progn
-          (when (plist-member kwargs :prompt)
-            (setf (macher-context-prompt persistent-ctx) (plist-get kwargs :prompt)))
-          (when (plist-member kwargs :process-request-function)
-            (setf (macher-context-process-request-function persistent-ctx) (plist-get kwargs :process-request-function)))
-
-          (when-let* ((contents (plist-get kwargs :contents)))
-            (dolist (e contents)
-              (let ((path (car e))
-                    (curr (if (consp (cdr e)) (cddr e) (cdr e))))
-                (macher-agent--update-context-file persistent-ctx path curr))))
-
+          (when (plist-member args :prompt)
+            (setf (macher-context-prompt persistent-ctx) (plist-get args :prompt)))
+          (when (plist-member args :process-request-function)
+            (setf (macher-context-process-request-function persistent-ctx) (plist-get args :process-request-function)))
           persistent-ctx)
+      (apply orig-fun args))))
 
-      (apply orig-fn kwargs))))
-
-(advice-add 'macher--make-context :around #'macher-agent--override-make-context)
-
-(defun macher-agent--propagate-vfs-to-gptel-target (orig-fn prompt &rest kwargs)
-  "Ensure that temporary buffers spawned for async requests inherit the live VFS context.
-This prevents data loss when external packages (like macher) evaluate LLM responses
-in temporary buffers that lack the agent's buffer-local state.
-
-ORIG-FN is the original request function.
-PROMPT is the prompt string.
-KWARGS represents extra keyword arguments.
-
-Return the result of ORIG-FN."
-  (when-let* ((live-ctx (bound-and-true-p macher-agent--persistent-context))
-              (raw-buf (plist-get kwargs :buffer))
-              (target-buf (when raw-buf (get-buffer raw-buf)))
-              ((not (eq target-buf (current-buffer)))))
-    (with-current-buffer target-buf
-      (setq-local macher-agent--persistent-context live-ctx)))
-
-  (apply orig-fn prompt kwargs))
-
-(advice-add 'gptel-request :around #'macher-agent--propagate-vfs-to-gptel-target)
+(advice-add 'macher--make-context :around #'macher-agent--around-make-context)
 
 (cl-defun macher-agent--make-vfs-context (&key workspace contents)
-  "Create an ephemeral context, safely bypassing the singleton constructor interceptor.
+  "Create a native `macher-context` struct using `macher--make-context`.
 
 WORKSPACE is the workspace object.
 CONTENTS is the list of VFS entries.
 
 Return the context struct."
-  (let ((macher-agent--bypass-context-override t))
+  (let ((macher-agent--persistent-context nil))
     (macher--make-context :workspace workspace :contents contents)))
 
 (defun macher-agent--prepare-patch-contexts (context fsm project-root)
@@ -174,59 +144,59 @@ CONTEXT is the active context structure.
 
 Return a cons cell of (PHYSICAL-CONTEXT . VIRTUAL-CONTEXT)."
   (let* ((ws (macher-agent--get-context-workspace context))
-         (project-root (macher-agent-root ws))
+         (project-root (macher-agent-workspace-project-root ws))
          (prepared (macher-agent--prepare-patch-contexts context nil project-root))
          (v-ctx (nth 0 prepared))
          (p-ctx (nth 1 prepared)))
     (cons p-ctx v-ctx)))
 
-(defun macher-agent--override-build-patch (orig-fn context &optional fsm)
-  "Intercept automated patch trigger, split contexts, and route back to core.
+(defun macher-agent-process-request (&optional status context fsm)
+  "Process request STATUS for CONTEXT and optional FSM.
+Split the context into physical and virtual parts and call `macher--build-patch` natively on both."
+  (let* ((ctx (cond
+               ((and status (fboundp 'macher-context-p) (macher-context-p status)) status)
+               (context context)
+               (t (ignore-errors (macher-agent-resolve-context)))))
+         (fsm-obj (cond
+                   ((and context (not (fboundp 'macher-context-p))) context)
+                   (fsm fsm)
+                   (t nil))))
+    (when ctx
+      (let* ((payloads (macher-agent-prepare-upstream-payloads ctx))
+             (p-ctx (car payloads))
+             (v-ctx (cdr payloads))
+             (generated-buffers nil)
+             (has-changes-p (lambda (c)
+                              (and c
+                                   (cl-some (lambda (entry)
+                                              (let ((orig (if (consp (cdr entry)) (cadr entry) nil))
+                                                    (curr (if (consp (cdr entry)) (cddr entry) (cdr entry))))
+                                                (not (equal (or orig "") (or curr "")))))
+                                            (macher-agent--get-context-contents c))))))
+        (when (funcall has-changes-p p-ctx)
+          (macher--build-patch p-ctx fsm-obj)
+          (when-let* ((buf (macher-patch-buffer (macher-context-workspace p-ctx)))
+                      (name (buffer-name buf)))
+            (let ((new-name (if (string-match "^\\*macher-patch\\(.*\\)\\*$" name)
+                                (concat "*macher-physical-patch" (match-string 1 name) "*")
+                              "*macher-physical-patch*")))
+              (with-current-buffer buf
+                (rename-buffer new-name t)
+                (push (current-buffer) generated-buffers)))))
+        (when (funcall has-changes-p v-ctx)
+          (macher--build-patch v-ctx fsm-obj)
+          (when-let* ((buf (macher-patch-buffer (macher-context-workspace v-ctx)))
+                      (name (buffer-name buf)))
+            (let ((new-name (if (string-match "^\\*macher-patch\\(.*\\)\\*$" name)
+                                (concat "*macher-virtual-patch" (match-string 1 name) "*")
+                              "*macher-virtual-patch*")))
+              (with-current-buffer buf
+                (rename-buffer new-name t)
+                (push (current-buffer) generated-buffers)))))
+        (unless generated-buffers
+          (message "Macher-Agent: No pending physical or virtual edits to review."))))))
 
-ORIG-FN is the original patch building function.
-CONTEXT is the active context structure.
-FSM is the optional finite-state machine.
-
-Return nil."
-  (let* ((payloads (macher-agent-prepare-upstream-payloads context))
-         (p-ctx (car payloads))
-         (v-ctx (cdr payloads))
-         (generated-buffers nil)
-         
-         (has-changes-p (lambda (ctx)
-                          (and ctx
-                               (cl-some (lambda (entry)
-                                          (let ((orig (if (consp (cdr entry)) (cadr entry) nil))
-                                                (curr (if (consp (cdr entry)) (cddr entry) (cdr entry))))
-                                            (not (equal (or orig "") (or curr "")))))
-                                        (macher-agent--get-context-contents ctx))))))
-    
-    (when (funcall has-changes-p p-ctx)
-      (funcall orig-fn p-ctx fsm)
-      (when-let* ((buf (macher-patch-buffer (macher-context-workspace p-ctx)))
-                  (name (buffer-name buf)))
-        (let ((new-name (if (string-match "^\\*macher-patch\\(.*\\)\\*$" name)
-                            (concat "*macher-physical-patch" (match-string 1 name) "*")
-                          "*macher-physical-patch*")))
-          (with-current-buffer buf
-            (rename-buffer new-name t)
-            (push (current-buffer) generated-buffers)))))
-    
-    (when (funcall has-changes-p v-ctx)
-      (funcall orig-fn v-ctx fsm)
-      (when-let* ((buf (macher-patch-buffer (macher-context-workspace v-ctx)))
-                  (name (buffer-name buf)))
-        (let ((new-name (if (string-match "^\\*macher-patch\\(.*\\)\\*$" name)
-                            (concat "*macher-virtual-patch" (match-string 1 name) "*")
-                          "*macher-virtual-patch*")))
-          (with-current-buffer buf
-            (rename-buffer new-name t)
-            (push (current-buffer) generated-buffers)))))
-    
-    (unless generated-buffers
-      (message "Macher-Agent: No pending physical or virtual edits to review."))))
-
-(advice-add 'macher--build-patch :around #'macher-agent--override-build-patch)
+(setq macher-process-request-function #'macher-agent-process-request)
 
 (defun macher-agent--get-context-workspace (ctx)
   "Retrieve the workspace from context CTX.

--- a/macher-agent-orchestration.el
+++ b/macher-agent-orchestration.el
@@ -253,7 +253,7 @@ CALLBACK is the function to run with the final result."
     (with-current-buffer buf
       (setq-local macher-agent--is-subagent t)
       (setq-local macher-agent--parent-buffer parent-buf)
-      
+
       (setq-local macher-agent--parent-callback
                   (lambda (res)
                     (unless callback-fired
@@ -262,7 +262,7 @@ CALLBACK is the function to run with the final result."
                         (with-current-buffer buf
                           (setq-local macher-agent--ready-to-reap t)))
                       (funcall callback res))))
-      
+
       (condition-case err
           (if (functionp payload)
               (funcall payload macher-agent--parent-callback)

--- a/macher-agent-vfs-client.el
+++ b/macher-agent-vfs-client.el
@@ -8,22 +8,185 @@
 
 (declare-function macher-agent-sync-prompt-transformer "macher-agent-gptel-bridge")
 
-(cl-defstruct macher-agent-workspace
-  "A shared singleton per project root managing the VFS state."
-  project-root
-  (vfs-buffers (make-hash-table :test 'equal))
-  (mtime-tracker (make-hash-table :test 'equal))
-  (tools-registry (make-hash-table :test 'equal))
-  (skills-alist nil)
-  (active-subagents nil))
+(defun macher-agent--get-context-data (ctx key &optional default)
+  "Retrieve KEY from the native data slot of CTX.
+
+CTX is the context structure.
+KEY is the lookup key symbol.
+DEFAULT is the value returned if KEY is not present.
+
+Return the value or DEFAULT."
+  (if (and ctx (fboundp 'macher-context-p) (macher-context-p ctx) (fboundp 'macher-context-data))
+      (let ((data (macher-context-data ctx)))
+        (if (plist-member data key)
+            (plist-get data key)
+          default))
+    default))
+
+(defun macher-agent--set-context-data (ctx key val)
+  "Set KEY to VAL in the native data slot of CTX.
+
+CTX is the context structure.
+KEY is the key symbol.
+VAL is the value to store.
+
+Return VAL."
+  (when (and ctx (fboundp 'macher-context-p) (macher-context-p ctx) (fboundp 'macher-context-data))
+    (let ((data (macher-context-data ctx)))
+      (setf (macher-context-data ctx)
+            (plist-put data key val))))
+  val)
+
+(defun macher-agent--resolve-context-from-ws (ws-or-ctx)
+  "Resolve WS-OR-CTX into a `macher-context` struct if possible.
+
+WS-OR-CTX is a workspace object, cons cell, or context struct.
+
+Return the resolved `macher-context` struct, or nil."
+  (cond
+   ((and ws-or-ctx (fboundp 'macher-context-p) (macher-context-p ws-or-ctx))
+    ws-or-ctx)
+   ((and (consp ws-or-ctx) (eq (car ws-or-ctx) 'project) (stringp (cdr ws-or-ctx)))
+    (or (gethash (file-name-as-directory (expand-file-name (cdr ws-or-ctx))) macher-agent-active-workspaces)
+        (gethash (directory-file-name (expand-file-name (cdr ws-or-ctx))) macher-agent-active-workspaces)
+        (gethash (expand-file-name (cdr ws-or-ctx)) macher-agent-active-workspaces)))
+   ((and (consp ws-or-ctx) (eq (car ws-or-ctx) 'agent))
+    (if (stringp (cdr ws-or-ctx))
+        (or (gethash (file-name-as-directory (expand-file-name (cdr ws-or-ctx))) macher-agent-active-workspaces)
+            (gethash (directory-file-name (expand-file-name (cdr ws-or-ctx))) macher-agent-active-workspaces)
+            (gethash (expand-file-name (cdr ws-or-ctx)) macher-agent-active-workspaces))
+      (ignore-errors (macher-agent-resolve-context))))
+   ((stringp ws-or-ctx)
+    (or (gethash (file-name-as-directory (expand-file-name ws-or-ctx)) macher-agent-active-workspaces)
+        (gethash (directory-file-name (expand-file-name ws-or-ctx)) macher-agent-active-workspaces)
+        (gethash (expand-file-name ws-or-ctx) macher-agent-active-workspaces)))
+   (t (ignore-errors (macher-agent-resolve-context)))))
+
+(cl-defun make-macher-agent-workspace (&key project-root &allow-other-keys)
+  "Construct a standard workspace cons cell `(project . PROJECT-ROOT)`.
+
+PROJECT-ROOT is the root directory path.
+
+Return a workspace cons cell."
+  (cons 'project (and project-root (expand-file-name project-root))))
+
+(defun macher-agent-workspace-p (ws)
+  "Return non-nil if WS is a valid workspace identifier.
+
+WS is the object to check."
+  (or (and (consp ws) (eq (car ws) 'project))
+      (and (consp ws) (eq (car ws) 'agent))
+      (stringp ws)))
+
+(defun macher-agent-workspace-project-root (ws)
+  "Retrieve the project root from workspace WS.
+
+WS is the workspace cons cell, string, or struct.
+
+Return the project root path string."
+  (cond
+   ((and (consp ws) (eq (car ws) 'project)) (expand-file-name (cdr ws)))
+   ((and (consp ws) (eq (car ws) 'agent) (stringp (cdr ws))) (expand-file-name (cdr ws)))
+   ((stringp ws) (expand-file-name ws))
+   ((consp ws) (expand-file-name (cdr ws)))
+   (t nil)))
+
+(defun macher-agent-workspace-vfs-buffers (ws-or-ctx)
+  "Retrieve the VFS buffers hash-table for WS-OR-CTX.
+
+WS-OR-CTX is a workspace object or context structure.
+
+Return a hash-table."
+  (let ((ctx (macher-agent--resolve-context-from-ws ws-or-ctx)))
+    (if ctx
+        (or (macher-agent--get-context-data ctx :vfs-buffers)
+            (let ((ht (make-hash-table :test 'equal)))
+              (macher-agent--set-context-data ctx :vfs-buffers ht)
+              ht))
+      (make-hash-table :test 'equal))))
+
+(defun macher-agent-workspace-mtime-tracker (ws-or-ctx)
+  "Retrieve the mtime tracker hash-table for WS-OR-CTX.
+
+WS-OR-CTX is a workspace object or context structure.
+
+Return a hash-table."
+  (let ((ctx (macher-agent--resolve-context-from-ws ws-or-ctx)))
+    (if ctx
+        (or (macher-agent--get-context-data ctx :mtime-tracker)
+            (let ((ht (make-hash-table :test 'equal)))
+              (macher-agent--set-context-data ctx :mtime-tracker ht)
+              ht))
+      (make-hash-table :test 'equal))))
+
+(defun macher-agent-workspace-tools-registry (ws-or-ctx)
+  "Retrieve the tools registry hash-table for WS-OR-CTX.
+
+WS-OR-CTX is a workspace object or context structure.
+
+Return a hash-table."
+  (let ((ctx (macher-agent--resolve-context-from-ws ws-or-ctx)))
+    (if ctx
+        (or (macher-agent--get-context-data ctx :tools-registry)
+            (let ((ht (make-hash-table :test 'equal)))
+              (macher-agent--set-context-data ctx :tools-registry ht)
+              ht))
+      macher-agent-tools-registry)))
+
+(defun macher-agent-workspace-skills-alist (ws-or-ctx)
+  "Retrieve the skills alist for WS-OR-CTX.
+
+WS-OR-CTX is a workspace object or context structure.
+
+Return an alist."
+  (let ((ctx (macher-agent--resolve-context-from-ws ws-or-ctx)))
+    (if ctx
+        (macher-agent--get-context-data ctx :skills-alist)
+      macher-agent-global-skills-alist)))
+
+(defun macher-agent-workspace-active-subagents (ws-or-ctx)
+  "Retrieve the active subagents list for WS-OR-CTX.
+
+WS-OR-CTX is a workspace object or context structure.
+
+Return a list of subagent entries."
+  (let ((ctx (macher-agent--resolve-context-from-ws ws-or-ctx)))
+    (when ctx
+      (macher-agent--get-context-data ctx :active-subagents))))
+
+(defun macher-agent--set-workspace-skills-alist (ws-or-ctx val)
+  "Set the skills alist for WS-OR-CTX to VAL."
+  (let ((ctx (macher-agent--resolve-context-from-ws ws-or-ctx)))
+    (if ctx
+        (macher-agent--set-context-data ctx :skills-alist val)
+      (setq macher-agent-global-skills-alist val)))
+  val)
+
+(gv-define-setter macher-agent-workspace-skills-alist (val ws-or-ctx)
+  `(macher-agent--set-workspace-skills-alist ,ws-or-ctx ,val))
+
+(defun macher-agent--set-workspace-active-subagents (ws-or-ctx val)
+  "Set the active subagents list for WS-OR-CTX to VAL."
+  (let ((ctx (macher-agent--resolve-context-from-ws ws-or-ctx)))
+    (when ctx
+      (macher-agent--set-context-data ctx :active-subagents val)))
+  val)
+
+(gv-define-setter macher-agent-workspace-active-subagents (val ws-or-ctx)
+  `(macher-agent--set-workspace-active-subagents ,ws-or-ctx ,val))
+
+(defun macher-agent--set-workspace-tools-registry (ws-or-ctx val)
+  "Set the tools registry for WS-OR-CTX to VAL."
+  (let ((ctx (macher-agent--resolve-context-from-ws ws-or-ctx)))
+    (if ctx
+        (macher-agent--set-context-data ctx :tools-registry val)
+      (setq macher-agent-tools-registry val)))
+  val)
+
+(gv-define-setter macher-agent-workspace-tools-registry (val ws-or-ctx)
+  `(macher-agent--set-workspace-tools-registry ,ws-or-ctx ,val))
 
 (require 'macher-agent-macher-bridge)
-
-(cl-defstruct macher-agent-session
-  id
-  workspace
-  sandbox-path
-  (pending-media nil))
 
 (defvar macher-agent-context-mutated-hook nil)
 (defvar macher-agent--allow-lazy-init nil)
@@ -37,6 +200,8 @@ WORKSPACE is the workspace structure.
 PATH is the relative or absolute path string.
 
 Return the node's content, or nil."
+  (unless workspace
+    (error "VFS Read Error: Workspace/Context cannot be nil"))
   (gethash path (macher-agent-workspace-vfs-buffers workspace)))
 
 (defun macher-agent-vfs-set-node (workspace path content)
@@ -47,6 +212,8 @@ PATH is the relative or absolute path string.
 CONTENT is the string content to store.
 
 Return the stored content."
+  (unless workspace
+    (error "VFS Write Error: Workspace/Context cannot be nil"))
   (puthash path content (macher-agent-workspace-vfs-buffers workspace)))
 
 (defun macher-agent-vfs-write (workspace file-path content)
@@ -57,6 +224,8 @@ FILE-PATH is the relative or absolute path string.
 CONTENT is the string content to write.
 
 Return the stored content."
+  (unless workspace
+    (error "VFS Write Error: Workspace/Context cannot be nil"))
   (let* ((tracker (macher-agent-workspace-mtime-tracker workspace))
          (original-mtime (gethash file-path tracker))
          (current-attrs (file-attributes file-path))
@@ -65,7 +234,11 @@ Return the stored content."
       (error "Your previous edits to %s were discarded due to external file modifications.  Please re-read and re-apply"
              (file-name-nondirectory file-path)))
     (puthash file-path current-mtime tracker)
-    (puthash file-path content (macher-agent-workspace-vfs-buffers workspace))))
+    (puthash file-path content (macher-agent-workspace-vfs-buffers workspace))
+    (let ((ctx (macher-agent--resolve-context-from-ws workspace)))
+      (when ctx
+        (macher-agent--update-context-file ctx file-path content)))
+    content))
 
 (defun macher-agent-vfs-read (workspace file-path)
   "Read a node's content from the virtual file system or physical disk.
@@ -74,10 +247,14 @@ WORKSPACE is the workspace structure.
 FILE-PATH is the relative or absolute path string.
 
 Return the content string, or nil."
-  (let ((content (gethash file-path (macher-agent-workspace-vfs-buffers workspace))))
-    (if content
-        content
-      (macher-agent--read-content-from-disk-or-buffer file-path))))
+  (unless workspace
+    (error "VFS Read Error: Workspace/Context cannot be nil"))
+  (or (gethash file-path (macher-agent-workspace-vfs-buffers workspace))
+      (when-let* ((ctx (macher-agent--resolve-context-from-ws workspace))
+                  (contents (macher-agent--get-context-contents ctx))
+                  (entry (cl-find file-path contents :key #'car :test #'equal)))
+        (if (consp (cdr entry)) (cddr entry) (cdr entry)))
+      (macher-agent--read-content-from-disk-or-buffer file-path)))
 
 (defun macher-agent-vfs-make-entry (path orig curr)
   "Create a native VFS entry tuple (PATH ORIG . CURR).
@@ -158,55 +335,16 @@ Return non-nil if it is a media file, otherwise nil."
                            (string-prefix-p "audio/" mime)))
              (string-match-p "\\.\\(png\\|jpe?g\\|gif\\|webp\\|svg\\|pdf\\|mp4\\|mov\\|mp3\\|wav\\)$" path)))))
 
-(cl-defgeneric macher-agent-root (&optional obj)
-  "Resolve the absolute project or workspace root path from OBJ.
-OBJ can be a string path, a buffer, a virtual file system context, a workspace struct, or nil.
-Returns the absolute path string, or nil if unresolved.")
-
-(cl-defmethod macher-agent-root ((obj string))
-  "Resolve the absolute project root from string OBJ."
-  (let* ((proj (and (fboundp 'project-current) (project-current nil obj))))
+(defun macher-agent-root (&optional path)
+  "Resolve the absolute project root path from primitive string PATH.
+PATH is a string directory or file path (or nil, defaulting to `default-directory`).
+Return the absolute project root path string."
+  (let* ((dir (if (stringp path) path default-directory))
+         (proj (and (fboundp 'project-current) (project-current nil dir))))
     (expand-file-name
      (or (and proj (if (fboundp 'project-root) (project-root proj) (cdr proj)))
-         (and (fboundp 'vc-root-dir) (let ((default-directory obj)) (vc-root-dir)))
-         obj))))
-
-(cl-defmethod macher-agent-root ((obj buffer))
-  "Resolve the absolute project root from buffer OBJ."
-  (with-current-buffer obj
-    (macher-agent-root default-directory)))
-
-(cl-defmethod macher-agent-root ((obj macher-agent-workspace))
-  "Resolve the absolute project root from workspace struct OBJ."
-  (macher-agent-workspace-project-root obj))
-
-(cl-defmethod macher-agent-root ((obj cons))
-  "Resolve the absolute project root from cons cell OBJ."
-  (cond
-   ((and (eq (car obj) 'agent) (not (stringp (cdr obj))))
-    (let ((ws (cdr obj)))
-      (if ws
-          (macher-agent-root ws)
-        (macher-agent-root default-directory))))
-   ((and (eq (car obj) 'project) (stringp (cdr obj)))
-    (expand-file-name (cdr obj)))
-   (t (macher-agent-root default-directory))))
-
-(cl-defmethod macher-agent-root ((obj null))
-  "Resolve the absolute project root when OBJ is nil."
-  (macher-agent-root default-directory))
-
-(cl-defmethod macher-agent-root (obj)
-  "Fallback method to resolve the absolute project root from OBJ."
-  (cond
-   ((and obj (fboundp 'macher-context-p) (macher-context-p obj))
-    (let ((ws (macher-agent--get-context-workspace obj)))
-      (if ws
-          (macher-agent-root ws)
-        (macher-agent-root default-directory))))
-   ((and obj (fboundp 'macher--workspace-root))
-    (ignore-errors (macher--workspace-root obj)))
-   (t (macher-agent-root default-directory))))
+         (and (fboundp 'vc-root-dir) (let ((default-directory dir)) (vc-root-dir)))
+         dir))))
 
 (defun macher-agent--resolve-safe-path (unsafe-path base-dir)
   "Resolves UNSAFE-PATH strictly within BASE-DIR, preventing jailbreaks.
@@ -252,16 +390,15 @@ Return nil."
                   (delete-file sandbox-target-path)))))
           entries)))
 
-(defun macher-agent-sandbox-inflate (session)
-  "Inflate the VFS contents for SESSION into its physical sandbox directory.
+(defun macher-agent-sandbox-inflate (ctx)
+  "Inflate the VFS contents for CTX into its physical sandbox directory.
 
-SESSION is the macher-agent-session struct.
+CTX is the macher-context struct.
 
 Return nil."
-  (let* ((workspace (macher-agent-session-workspace session))
-         (sandbox-path (macher-agent-session-sandbox-path session))
-         (vfs-buffers (macher-agent-workspace-vfs-buffers workspace))
-         (ws-root (macher-agent-workspace-project-root workspace)))
+  (let* ((sandbox-path (macher-agent--get-context-data ctx :sandbox-path))
+         (vfs-buffers (macher-agent-workspace-vfs-buffers ctx))
+         (ws-root (macher-agent-context-root ctx)))
     (when sandbox-path
       (let ((entries (hash-table-keys vfs-buffers)))
         (macher-agent--vfs-process-entries
@@ -271,7 +408,8 @@ Return nil."
            (if (file-name-absolute-p key)
                (file-relative-name key ws-root)
              key))
-         (lambda (key) (gethash key vfs-buffers)))))))
+         (lambda (key) (gethash key vfs-buffers))))
+      (macher-agent--vfs-apply-overlay ctx sandbox-path))))
 
 (defun macher-agent-context-root (context)
   "Retrieve the project root directory string from CONTEXT.
@@ -279,7 +417,9 @@ Return nil."
 CONTEXT is the active context structure.
 
 Return the project root path string."
-  (or (macher-agent-root context) default-directory))
+  (or (when-let* ((ws (when context (macher-agent--get-context-workspace context))))
+        (macher-agent-workspace-project-root ws))
+      default-directory))
 
 (defun macher-agent--vfs-verify-clean-merge (workspace-root context)
   "Verify that the active CONTEXT can merge cleanly into WORKSPACE-ROOT.
@@ -308,7 +448,7 @@ Return the shell command string."
                       (call-process "git" nil nil nil "rev-parse" "--is-inside-work-tree")))
         (error "Macher-Agent: Source directory is not inside a Git repository: %s" src-dir)))
 
-    (format "(cd %s && git ls-files -c -o --exclude-standard) | rsync -aLC --delete --files-from=- %s %s"
+    (format "(cd %s && git -c core.quotePath=false ls-files -z -c -o --exclude-standard) | rsync -aLC --delete --from0 --files-from=- %s %s"
             (shell-quote-argument src-dir)
             (shell-quote-argument src-dir)
             (shell-quote-argument dest-dir))))
@@ -412,7 +552,9 @@ CONTEXT is the active context structure.
 PATH is the string file path.
 
 Return nil or signals an error."
-  (macher-agent--ensure-access-stateless (and context (macher-agent--get-context-contents context)) path))
+  (unless context
+    (error "VFS Error: Context cannot be nil"))
+  (macher-agent--ensure-access-stateless (macher-agent--get-context-contents context) path))
 
 (defun macher-agent--inject-context-state (context &optional directives)
   "Explicitly inject the active agent CONTEXT and optional DIRECTIVES into the current buffer.
@@ -439,12 +581,10 @@ Return the resolved context structure, or nil."
 
 FSM is the finite-state machine object.
 
-Return the info property list, or nil."
-  (when fsm
-    (if (fboundp 'gptel-fsm-info)
-        (funcall 'gptel-fsm-info fsm)
-      (when (fboundp 'mock-gptel-fsm-info)
-        (funcall 'mock-gptel-fsm-info fsm)))))
+Return the info property list."
+  (unless fsm
+    (error "FSM Error: State machine object cannot be nil"))
+  (gptel-fsm-info fsm))
 
 (defun macher-agent--extract-fsm-context (fsm)
   "Extract the active context from a finite-state machine (FSM).
@@ -452,9 +592,9 @@ Return the info property list, or nil."
 FSM is the finite-state machine object.
 
 Return the active context structure, or nil."
-  (let ((info (macher-agent--extract-fsm-info fsm)))
-    (and info (or (plist-get info :macher-agent-context)
-                  (plist-get info :macher--context)))))
+  (when fsm
+    (let ((info (macher-agent--extract-fsm-info fsm)))
+      (and info (plist-get info :macher-agent-context)))))
 
 (defun macher-agent-resolve-context (&optional ctx-or-fsm)
   "Resolve the active context from CTX-OR-FSM or state.
@@ -467,26 +607,30 @@ Follows a predictable waterfall:
 
 CTX-OR-FSM is the optional context or finite-state machine.
 
-Return the resolved context structure, or nil."
-  (cond
-   ((and ctx-or-fsm (fboundp 'macher-context-p) (macher-context-p ctx-or-fsm))
-    ctx-or-fsm)
-   ((macher-agent--extract-fsm-context ctx-or-fsm))
-   ((bound-and-true-p macher-agent--persistent-context)
-    macher-agent--persistent-context)
-   ((let ((fsm (macher-agent--get-fsm-latest)))
-      (macher-agent--extract-fsm-context fsm)))
-   (t
-    (if-let* ((active-root (macher-agent-root default-directory))
-              (active-root-expanded (expand-file-name active-root))
-              (primary-ctx (gethash active-root-expanded macher-agent-active-workspaces)))
-        primary-ctx
-      (if macher-agent--allow-lazy-init
-          (save-excursion
-            (let ((current-root (macher-agent-root default-directory)))
-              (macher-agent--init-workspace-state current-root)
-              (bound-and-true-p macher-agent--persistent-context)))
-        (error "No active agent session found"))))))
+Return the resolved context structure, or error if nil."
+  (let ((ctx
+         (cond
+          ((and ctx-or-fsm (fboundp 'macher-context-p) (macher-context-p ctx-or-fsm))
+           ctx-or-fsm)
+          ((macher-agent--extract-fsm-context ctx-or-fsm))
+          ((bound-and-true-p macher-agent--persistent-context)
+           macher-agent--persistent-context)
+          ((let ((fsm (macher-agent--get-fsm-latest)))
+             (macher-agent--extract-fsm-context fsm)))
+          (t
+           (if-let* ((active-root (macher-agent-root default-directory))
+                     (active-root-expanded (expand-file-name active-root))
+                     (primary-ctx (gethash active-root-expanded macher-agent-active-workspaces)))
+               primary-ctx
+             (if macher-agent--allow-lazy-init
+                 (save-excursion
+                   (let ((current-root (macher-agent-root default-directory)))
+                     (macher-agent--init-workspace-state current-root)
+                     (bound-and-true-p macher-agent--persistent-context)))
+               nil))))))
+    (unless ctx
+      (error "No active agent session found"))
+    ctx))
 
 (defun macher-agent--read-content-from-disk-or-buffer (path)
   "Read the contents of PATH from an active buffer or disk.
@@ -514,12 +658,13 @@ WORKSPACE-ROOT is the project root directory string.
 Return nil."
   (setq-local macher-agent--is-workspace t)
   (let* ((workspace (make-macher-agent-workspace :project-root workspace-root))
-         (macher-ws (cons 'agent workspace))
-         (context (macher-agent--make-vfs-context :workspace macher-ws :contents nil)))
-    (setq-local macher--workspace macher-ws)
+         (context (macher-agent--make-vfs-context :workspace workspace :contents nil)))
+    (setq-local macher--workspace workspace)
     (macher-agent--inject-context-state context)
 
     (puthash (expand-file-name workspace-root) context macher-agent-active-workspaces)
+    (puthash (file-name-as-directory (expand-file-name workspace-root)) context macher-agent-active-workspaces)
+    (puthash (directory-file-name (expand-file-name workspace-root)) context macher-agent-active-workspaces)
 
     (add-hook 'gptel-prompt-transform-functions #'macher-agent-sync-prompt-transformer nil t)
 
@@ -558,7 +703,7 @@ Return a cons cell of cloned contexts (FILE-CONTEXT . BUFFER-CONTEXT)."
   (let ((file-ctx (macher-agent--clone-context ctx))
         (buf-ctx (macher-agent--clone-context ctx))
         (workspace (when ctx (macher-agent--get-context-workspace ctx))))
-    (let* ((root (and workspace (macher-agent-root workspace)))
+    (let* ((root (and workspace (macher-agent-workspace-project-root workspace)))
            (contents (when ctx (macher-agent--get-context-contents ctx)))
 
            (modified-contents (cl-remove-if (lambda (e)
@@ -596,6 +741,8 @@ PATH is the relative file path string.
 NEW-CONTENT is the modified content string.
 
 Return nil."
+  (unless context
+    (error "VFS Write Error: Context cannot be nil"))
   (let* ((contents (macher-agent--get-context-contents context))
          (entry (cl-find path contents :key #'car :test #'equal)))
     (if entry
@@ -606,6 +753,7 @@ Return nil."
              (orig (macher-agent--get-buffer-content-stateless path workspace-root)))
         (macher-agent--set-context-contents context
                                             (cons (cons path (cons orig new-content)) contents))))
+    (puthash path new-content (macher-agent-workspace-vfs-buffers context))
     (macher-agent--set-context-dirty-p context t)
     (macher-agent--persist-vfs-to-hidden-buffer context)
     (run-hook-with-args 'macher-agent-context-mutated-hook path)))
@@ -629,8 +777,10 @@ CONTEXT is the active context structure.
 PATH is the file path string to read.
 
 Return the file content string."
-  (let* ((contents (and context (macher-agent--get-context-contents context)))
-         (workspace-root (macher-context-workspace-root context)))
+  (unless context
+    (error "VFS Read Error: Context cannot be nil"))
+  (let ((contents (macher-agent--get-context-contents context))
+        (workspace-root (macher-context-workspace-root context)))
     (macher-agent--ensure-access-stateless contents path)
     (if-let* ((virtual-entry (cl-find path contents :key #'car :test #'equal))
               (virtual-content (if (consp (cdr virtual-entry)) (cddr virtual-entry) (cdr virtual-entry))))
@@ -779,7 +929,7 @@ Return non-nil if synchronisation modified the entry, otherwise nil."
          (current-state (macher-agent--read-content-from-disk-or-buffer path)))
     (if (not (equal (or orig "") (or current-state "")))
         (if (equal (or new "") (or current-state ""))
-            (progn 
+            (progn
               (if (consp (cdr entry))
                   (setcar (cdr entry) current-state)
                 (setcdr entry (cons current-state new)))
@@ -816,9 +966,9 @@ Return nil."
                 (new (if (consp (cdr entry)) (cddr entry) (cdr entry))))
             (unless (equal (or orig "") (or new ""))
               (setq is-dirty t)))))
-      
+
       (macher-agent--set-context-dirty-p ctx is-dirty)
-      
+
       (when synced
         (macher-agent--persist-vfs-to-hidden-buffer ctx)
         (run-hooks 'macher-agent-context-mutated-hook)))))
@@ -830,7 +980,7 @@ CTX is the active context structure.
 
 Return nil."
   (let* ((workspace (when ctx (macher-agent--get-context-workspace ctx)))
-         (root-dir (if workspace (macher-agent-root workspace) "default"))
+         (root-dir (if workspace (macher-agent-workspace-project-root workspace) "default"))
          (buf-name (format " *macher-agent-vfs-state-%s*" (md5 (expand-file-name root-dir))))
          (vfs-buf (get-buffer-create buf-name)))
     (with-current-buffer vfs-buf
@@ -857,7 +1007,7 @@ Return nil."
          (ws (or (when ctx (macher-agent--get-context-workspace ctx))
                  (bound-and-true-p macher--workspace)))
          (root (if ws
-                   (macher-agent-root ws)
+                   (macher-agent-workspace-project-root ws)
                  (or (locate-dominating-file default-directory ".git") default-directory)))
          (default-directory (file-name-as-directory (expand-file-name root)))
          (use-git (locate-dominating-file default-directory ".git"))
@@ -893,7 +1043,7 @@ Return nil."
   (if (not macher-agent--persistent-context)
       (message "No active context to clear in this buffer.")
     (let* ((ws (macher-agent--get-context-workspace macher-agent--persistent-context))
-           (ws-root (and ws (macher-agent-root ws))))
+           (ws-root (and ws (macher-agent-workspace-project-root ws))))
       (when ws-root
         (remhash (expand-file-name ws-root) macher-agent-active-workspaces))
       (setq-local macher-agent--persistent-context nil)

--- a/macher-agent.el
+++ b/macher-agent.el
@@ -1,7 +1,7 @@
 ;;; macher-agent.el --- Sandboxed, Language-Agnostic AI Workflows -*- lexical-binding: t; -*-
 
 ;; Author: Elijah Charles
-;; Version: 0.8.0.53
+;; Version: 0.8.0.56
 ;; Package-Requires: ((emacs "30.1") (gptel "0.9.9.6") (macher "0.5.2"))
 ;; Keywords: convenience, gptel, llm, macher
 ;; URL: https://github.com/elij/macher-agent

--- a/skills/scripts/commit_buffer.el
+++ b/skills/scripts/commit_buffer.el
@@ -1,22 +1,23 @@
 (macher-agent-make-tool macher-agent-commit-buffer-tool
-    "Directly appends an Emacs buffer and synchronise the agent's memory immediately, bypassing the patch review step."
+    "Directly appends an Emacs buffer and synchronise the agent's memory immediately, \
+bypassing the patch review step."
   :category "plan"
   :args (list '(:name "buffer_name" :type string)
               '(:name "content" :type string))
   :command-fn (lambda (payload context _root)
-                (let ((buffer_name (plist-get payload :buffer_name))
-                      (content (plist-get payload :content)))
-                  (let ((actual-name (macher-agent--resolve-buffer-name buffer_name)))
-                    (macher-agent--ensure-access context actual-name)
-                    (let ((target-buffer (get-buffer-create actual-name)))
-                      (with-current-buffer target-buffer
-                        (when (bound-and-true-p auto-save-visited-mode)
-                          (auto-save-visited-mode -1))
-                        (goto-char (point-max))
-                        (insert content)
-                        (set-buffer-modified-p t))
-                      (when context
-                        (macher-agent--update-context-file context actual-name content)
-                        (macher-agent--auto-sync-context context))
-                      (make-macher-agent-lisp-result-response
-                       :payload (format "SUCCESS: Buffer '%s' has been directly overwritten and synchronised. Awaiting user save." actual-name)))))))
+                (let* ((buffer_name (plist-get payload :buffer_name)))
+                  (content (plist-get payload :content))
+                  (actual-name (macher-agent--resolve-buffer-name buffer_name))
+                  (_ (macher-agent--ensure-access context actual-name))
+                  (target-buffer (get-buffer-create actual-name))
+                  (with-current-buffer target-buffer
+                    (auto-save-visited-mode -1)
+                    (goto-char (point-max))
+                    (insert content)
+                    (set-buffer-modified-p t))
+                  (when context
+                    (macher-agent--update-context-file context actual-name content)
+                    (macher-agent--auto-sync-context context))
+                  (make-macher-agent-lisp-result-response
+                   :payload (format "SUCCESS: Buffer '%s' has been directly \
+overwritten and synchronised. Awaiting user save." actual-name)))))

--- a/skills/scripts/delegate_tasks_to_subagents.el
+++ b/skills/scripts/delegate_tasks_to_subagents.el
@@ -1,33 +1,30 @@
 (macher-agent-make-tool macher-agent-delegate-tasks-to-subagents-tool
     "Delegate tasks to multiple sub-agents asynchronously."
   :category "orchestrate"
-  :args (list '(:name "tasks" :type array :items (:type object :properties (:buffer_name (:type string) :instructions (:type string) :presets (:type array :items (:type string))))))
-  :command-fn (lambda (payload)
+  :args (list '(:name "tasks" :type array :items
+                      (:type object :properties
+                             (:buffer_name (:type string)
+                                           :instructions (:type string)
+                                           :presets (:type array :items (:type string))))))
+  :command-fn (lambda (payload _context _root)
                 (let* ((raw-tasks (plist-get payload :tasks))
                        (normalized-tasks
                         (cl-loop for task-obj in (append raw-tasks nil)
-                                 collect (let* ((raw-presets (or (plist-get task-obj :presets)
-                                                                 (alist-get 'presets task-obj)
-                                                                 (alist-get "presets" task-obj nil nil #'equal)))
-                                                (preset-list (cond ((vectorp raw-presets) (append raw-presets nil))
-                                                                   ((stringp raw-presets) (list raw-presets))
-                                                                   ((listp raw-presets) raw-presets)
-                                                                   (t nil))))
-                                           (list :buffer_name (or (plist-get task-obj :buffer_name)
-                                                                  (alist-get 'buffer_name task-obj)
-                                                                  (alist-get "buffer_name" task-obj nil nil #'equal))
-                                                 :instructions (or (plist-get task-obj :instructions)
-                                                                   (alist-get 'instructions task-obj)
-                                                                   (alist-get "instructions" task-obj nil nil #'equal))
-                                                 :presets preset-list)))))
+                                 collect (list
+                                          :buffer_name (plist-get task-obj :buffer_name)
+                                          :instructions (plist-get task-obj :instructions)
+                                          :presets
+                                          (append (plist-get task-obj :presets) nil)))))
                   (make-macher-agent-delegate-response :payload (vconcat normalized-tasks))))
   :success-fn (lambda (results)
                 (let ((output (list "All sub-agents completed. Outputs:\n")))
                   (cl-loop for res across (if (vectorp results) results (vconcat results))
-                           do (push (format "=== Response from %s ===\n%s\n" 
-                                            (macher-agent-tool-response-buffer-name res)
-                                            (if (eq (macher-agent-tool-response-status res) 'success)
-                                                (macher-agent-tool-response-data res)
-                                              (macher-agent-tool-response-error res)))
-                                    output))
+                           do (push
+                               (format "=== Response from %s ===%s\n"
+                                       (macher-agent-tool-response-buffer-name res)
+                                       (if (eq
+                                            (macher-agent-tool-response-status res) 'success)
+                                           (macher-agent-tool-response-data res)
+                                         (macher-agent-tool-response-error res)))
+                               output))
                   (string-join (nreverse output) "\n"))))

--- a/skills/scripts/execute_subagents.el
+++ b/skills/scripts/execute_subagents.el
@@ -1,36 +1,34 @@
 (macher-agent-make-tool macher-agent-execute-subagents-tool
-    "Execute tasks across multiple sub-agents in parallel in a fire-and-forget, non-blocking manner."
+    "Execute tasks across multiple sub-agents in parallel in a fire-and-forget, \
+non-blocking manner."
   :category "orchestrate"
-  :args '((:name "tasks" :type array :description "An array of task objects to execute in parallel in the background."
-                 :items (:type object
-                               :properties (:buffer_name (:type string)
-                                                         :instructions (:type string)
-                                                         :presets (:type array :items (:type string)))
+  :args '(
+          (:name "tasks" :type array
+                 :description "An array of task objects to execute in parallel in `
+the background."
+                 :items (:type object :properties (
+                                                   :buffer_name (:type string)
+                                                   :instructions (:type string)
+                                                   :presets (
+                                                             :type array :items (:type string)))
                                :required ["buffer_name" "instructions"])))
-  :command-fn (lambda (payload)
+  :command-fn (lambda (payload _context _root)
                 (let* ((raw-tasks (plist-get payload :tasks))
                        (normalized-tasks
                         (cl-loop for task-obj in (append raw-tasks nil)
-                                 collect (let* ((raw-presets (or (plist-get task-obj :presets)
-                                                                 (alist-get 'presets task-obj)
-                                                                 (alist-get "presets" task-obj nil nil #'equal)))
-                                                (preset-list (cond ((vectorp raw-presets) (append raw-presets nil))
-                                                                   ((stringp raw-presets) (list raw-presets))
-                                                                   ((listp raw-presets) raw-presets)
-                                                                   (t nil))))
-                                           (list :buffer_name (or (plist-get task-obj :buffer_name)
-                                                                  (alist-get 'buffer_name task-obj)
-                                                                  (alist-get "buffer_name" task-obj nil nil #'equal))
-                                                 :instructions (or (plist-get task-obj :instructions)
-                                                                   (alist-get 'instructions task-obj)
-                                                                   (alist-get "instructions" task-obj nil nil #'equal))
-                                                 :presets preset-list
-                                                 :background t)))))
+                                 collect (list
+                                          :buffer_name (plist-get task-obj :buffer_name)
+                                          :instructions (plist-get task-obj :instructions)
+                                          :presets (append (plist-get task-obj :presets) nil)
+                                          :background t))))
                   (dolist (task normalized-tasks)
-                    (macher-agent-spawn-task task (lambda (res) 
-                                                    (message "Background subagent %s task execution completed with status: %s"
+                    (macher-agent-spawn-task task (lambda (res)
+                                                    (message "Background subagent %s task \
+execution completed with status: %s"
                                                              (macher-agent-tool-response-buffer-name res)
                                                              (macher-agent-tool-response-status res)))))
                   (make-macher-agent-lisp-result-response
-                   :payload (format "SUCCESS: Dispatched %d sub-agents in the background. They are executing independently and asynchronously. Your current buffer remains unblocked and you can proceed with other tasks immediately."
+                   :payload (format "SUCCESS: Dispatched %d sub-agents in the background. \
+They are executing independently and asynchronously. Your current buffer remains unblocked \
+and you can proceed with other tasks immediately."
                                     (length normalized-tasks))))))

--- a/skills/scripts/list_buffers_in_workspace.el
+++ b/skills/scripts/list_buffers_in_workspace.el
@@ -1,15 +1,20 @@
 (macher-agent-make-tool macher-agent-list-buffers-in-workspace-tool
-  "List all buffers you currently have explicit access to. You cannot access buffers outside this list."
+    "List all buffers you currently have explicit access to. You cannot access buffers \
+outside this list."
   :category "ro"
   :args nil
   :command-fn (lambda (_payload context root-dir)
-                (let* ((active-buffers nil))
-                  (when context
-                    (dolist (entry (macher-agent--get-context-contents context))
-                      (let* ((buf-name (macher-agent-vfs-entry-path entry))
-                             (classification (macher-agent-context-classify-entry buf-name root-dir)))
-                        (when (memq classification '(buffer external))
-                          (push buf-name active-buffers)))))
-                  (if active-buffers
-                      (make-macher-agent-lisp-result-response :payload (mapconcat #'identity (nreverse active-buffers) "\n"))
-                    (make-macher-agent-lisp-result-response :payload "No buffers are currently in your scope.")))))
+                (let ((active-buffers
+                       (when-let* ((entries (and context
+                                                 (macher-agent--get-context-contents context))))
+                         (let (acc)
+                           (dolist (entry entries (nreverse acc))
+                             (let* ((buf-name (macher-agent-vfs-entry-path entry))
+                                    (classification
+                                     (macher-agent-context-classify-entry buf-name root-dir)))
+                               (when (memq classification '(buffer external))
+                                 (push buf-name acc))))))))
+                  (make-macher-agent-lisp-result-response
+                   :payload (if active-buffers
+                                (mapconcat #'identity active-buffers "\n")
+                              "No buffers are currently in your scope.")))))

--- a/skills/scripts/mark_self_for_reap.el
+++ b/skills/scripts/mark_self_for_reap.el
@@ -1,8 +1,10 @@
 (macher-agent-make-tool macher-agent-mark-self-for-reap
-    "Marks the current subagent buffer for termination. Call this exactly once when you have completely finished your assigned task."
+    "Marks the current subagent buffer for termination. Call this exactly once when you \
+have completely finished your assigned task."
   :category "worker"
   :args nil
   :command-fn (lambda (_payload _context _root)
                 (setq-local macher-agent--ready-to-reap t)
                 (make-macher-agent-lisp-result-response
-                 :payload "Success. This buffer has been marked for reaping and will be terminated shortly. Please finish your response.")))
+                 :payload "Success. This buffer has been marked for reaping and will be \
+terminated shortly. Please finish your response.")))

--- a/skills/scripts/multi_edit_buffer_in_workspace.el
+++ b/skills/scripts/multi_edit_buffer_in_workspace.el
@@ -1,35 +1,49 @@
 (macher-agent-make-tool macher-agent-multi-edit-buffer-in-workspace-tool
-                        "Apply 1-to-many replacements to one scoped buffer in your workspace sequentially. All edits use exact text matching (whitespace, newlines, indentation). Use actual content - NO line numbers.\n\nEdits apply in array order. If ANY edit fails, ALL changes are rolled back."
-                        :category "workspace"
-                        :args '((:name "buffer_name" :type string :description "The name of the target buffer")
-                                (:name "edits" :type array :description "Array of edit operations to apply in sequence"
-                                       :items (:type object
-                                                     :properties (:old_text (:type string :description "Exact text to find and replace.")
-                                                                            :new_text (:type string :description "Text to replace the old_text with")
-                                                                            :replace_all (:type boolean :description "If true, replace all occurrences."))
-                                                     :required ["old_text" "new_text"])))
-                        :command-fn (lambda (payload context _root)
-                                      (let* ((buffer_name (plist-get payload :buffer_name))
-                                             (edits (plist-get payload :edits))
-                                             (actual-name (macher-agent--resolve-buffer-name buffer_name))
-                                             (content (let ((contents (cl-find actual-name (macher-agent--get-context-contents context) :key #'macher-agent-vfs-entry-path :test #'equal)))
-                                                        (if contents
-                                                            (macher-agent-vfs-entry-curr contents)
-                                                          (error "Buffer '%s' not found in workspace" actual-name)))))
-                                        (unless (stringp buffer_name)
-                                          (error "Wrong type argument: stringp, %s" buffer_name))
-                                        (unless (vectorp edits)
-                                          (error "The 'edits' parameter must be an array of objects"))
-                                        (cl-loop for edit across edits do
-                                                 (let* ((old-text (plist-get edit :old_text))
-                                                        (new-text (plist-get edit :new_text))
-                                                        (replace-all (plist-get edit :replace_all))
-                                                        (replace-all-bool (and replace-all (not (eq replace-all :json-false)))))
-                                                   (unless (and old-text new-text)
-                                                     (error "Each edit must contain old_text and new_text properties"))
-                                                   (setq content (macher-agent--edit-string-fast content old-text new-text replace-all-bool))))
-                                        
-                                        (when context
-                                          (macher-agent--update-context-file context actual-name content))
-                                        
-                                        (make-macher-agent-lisp-result-response :payload (format "SUCCESS: Virtual multi-edit recorded for buffer '%s'. A patch will be generated at the end of the turn." actual-name)))))
+    "Apply 1-to-many replacements to one scoped buffer in your workspace sequentially. \
+All edits use exact text matching (whitespace, newlines, indentation). Use actual content - \
+NO line numbers.\n\nEdits apply in array order. If ANY edit fails, ALL changes are rolled \
+back."
+  :category "workspace"
+  :args '((:name "buffer_name" :type string :description "The name of the target buffer")
+          (:name "edits" :type array :description "Array of edit operations to apply in \
+sequence"
+                 :items (:type object
+                               :properties (:old_text (:type string :description "Exact \
+text \
+to find and replace.")
+                                                      :new_text (:type string
+                                                                       :description "Text \
+to replace the old_text with")
+                                                      :replace_all (:type boolean
+                                                                          :description "If \
+true, replace all occurrences."))
+                               :required ["old_text" "new_text"])))
+  :command-fn (lambda (payload context _root)
+                (let* ((buffer_name (plist-get payload :buffer_name))
+                       (edits (plist-get payload :edits))
+                       (actual-name (macher-agent--resolve-buffer-name buffer_name))
+                       (content
+                        (let ((contents
+                               (cl-find actual-name
+                                        (macher-agent--get-context-contents context)
+                                        :key #'macher-agent-vfs-entry-path :test #'equal)))
+                          (if contents
+                              (macher-agent-vfs-entry-curr contents)
+                            (error "Buffer '%s' not found in workspace" actual-name)))))
+                  (cl-loop for edit in (append edits nil) do
+                           (let* ((old-text (plist-get edit :old_text))
+                                  (new-text (plist-get edit :new_text))
+                                  (replace-all (plist-get edit :replace_all))
+                                  (replace-all-bool
+                                   (and replace-all (not (eq replace-all :json-false)))))
+                             (unless (and old-text new-text)
+                               (error "Each edit must contain old_text and new_text \
+properties"))
+                             (setq content
+                                   (macher-agent--edit-string-fast content old-text 
+                                                                   new-text replace-all-bool))))
+                  (when context
+                    (macher-agent--update-context-file context actual-name content))
+                  (make-macher-agent-lisp-result-response :payload (format "SUCCESS: \
+Virtual multi-edit recorded for buffer '%s'. A patch will be generated at the end of the \
+turn." actual-name)))))

--- a/skills/scripts/read_buffer_in_workspace.el
+++ b/skills/scripts/read_buffer_in_workspace.el
@@ -1,30 +1,31 @@
 (macher-agent-make-tool macher-agent-read-buffer-in-workspace-tool
-                        "Read the contents of a scoped buffer (ie a buffer in your allowed list)."
-                        :category "ro"
-                        :args '((:name "buffer_name" :type string :description "The name of the buffer to read")
-                                (:name "offset" :type number :optional t :description "Line number to start reading from (1-based)")
-                                (:name "limit" :type number :optional t :description "Number of lines to read")
-                                (:name "show_line_numbers" :type boolean :optional t :description "Include line numbers in output"))
-                        :command-fn (lambda (payload context _root)
-                                      (let* ((buffer_name (plist-get payload :buffer_name))
-                                             (offset (plist-get payload :offset))
-                                             (limit (plist-get payload :limit))
-                                             (show_line_numbers (plist-get payload :show_line_numbers)))
-                                        
-                                        ;; Auto-correct LLM positional argument skipping (boolean into offset/limit)
-                                        (when (memq offset '(t nil :json-false))
-                                          (unless show_line_numbers (setq show_line_numbers offset))
-                                          (setq offset nil))
-                                        (when (memq limit '(t nil :json-false))
-                                          (unless show_line_numbers (setq show_line_numbers limit))
-                                          (setq limit nil))
-                                        
-                                        (let* ((actual-name (macher-agent--resolve-buffer-name buffer_name))
-                                               (parsed-offset (when offset (round offset)))
-                                               (parsed-limit (when limit (round limit))))
-                                          (macher-agent--ensure-access context actual-name)
-                                          (let* ((contents (cl-find actual-name (macher-agent--get-context-contents context) :key #'macher-agent-vfs-entry-path :test #'equal))
-                                                 (content (if contents (macher-agent-vfs-entry-curr contents)
-                                                            (with-current-buffer (get-buffer actual-name)
-                                                              (buffer-substring-no-properties (point-min) (point-max))))))
-                                            (make-macher-agent-lisp-result-response :payload (macher--read-string content parsed-offset parsed-limit show_line_numbers)))))))
+    "Read the contents of a scoped buffer (ie a buffer in your allowed list)."
+  :category "ro"
+  :args '((:name "buffer_name" :type string :description "The name of the buffer to read")
+          (:name "offset" :type number :optional t :description "Line number to start \
+reading from (1-based)")
+          (:name "limit" :type number :optional t :description "Number of lines to read")
+          (:name "show_line_numbers" :type boolean :optional t :description "Include line \
+numbers in output"))
+  :command-fn (lambda (payload context _root)
+                (let* ((buffer_name (plist-get payload :buffer_name))
+                       (offset (plist-get payload :offset))
+                       (limit (plist-get payload :limit))
+                       (show_line_numbers (and (plist-get payload :show_line_numbers) 
+                                               (not (eq
+                                                     (plist-get payload :show_line_numbers)
+                                                     :json-false))))
+                       (actual-name (macher-agent--resolve-buffer-name buffer_name))
+                       (parsed-offset (when (numberp offset) (round offset)))
+                       (parsed-limit (when (numberp limit) (round limit))))
+                  (macher-agent--ensure-access context actual-name)
+                  (let* ((contents
+                          (cl-find actual-name (macher-agent--get-context-contents context)
+                                   :key #'macher-agent-vfs-entry-path :test #'equal))
+                         (content (if contents (macher-agent-vfs-entry-curr contents)
+                                    (with-current-buffer (get-buffer actual-name)
+                                      (buffer-substring-no-properties
+                                       (point-min) (point-max))))))
+                    (make-macher-agent-lisp-result-response
+                     :payload (macher--read-string
+                               content parsed-offset parsed-limit show_line_numbers))))))

--- a/skills/scripts/read_media_in_workspace.el
+++ b/skills/scripts/read_media_in_workspace.el
@@ -1,39 +1,42 @@
 (macher-agent-make-tool macher-agent-read-media-in-workspace-tool
-    "Read a media file (for example, an image) from the workspace into the agent's visual context."
+    "Read a media file (for example, an image) from the workspace into \
+the agent's visual context."
   :category "ro"
-  :args '((:name "media_path" :type string :description "The path to the media file relative to the workspace root."))
-  :command-fn (lambda (payload)
+  :args '((:name "media_path" :type string :description "The path to the media file \
+relative to the workspace root."))
+  :command-fn (lambda (payload context root)
                 (let* ((media_path (plist-get payload :media_path))
-                       (context (ignore-errors (macher-agent-resolve-context)))
-                       (workspace (when context (macher-agent--get-context-workspace context)))
-                       (workspace-root (when context (macher-context-workspace-root context)))
+                       (workspace
+                        (when context
+                          (macher-agent--get-context-workspace context)))
+                       (workspace-root
+                        (when context
+                          (macher-context-workspace-root context)))
                        (actual-name (if (fboundp 'macher-agent--resolve-buffer-name)
                                         (macher-agent--resolve-buffer-name media_path)
                                       media_path))
                        (abs-path (if workspace-root
                                      (expand-file-name actual-name workspace-root)
                                    (expand-file-name actual-name)))
-                       (vfs-contents (when context (macher-agent--get-context-contents context)))
-                       (in-vfs (cl-find actual-name vfs-contents :key #'macher-agent-vfs-entry-path :test #'equal)))
-                  
+                       (vfs-contents
+                        (when context
+                          (macher-agent--get-context-contents context)))
+                       (in-vfs
+                        (cl-find actual-name vfs-contents :key #'macher-agent-vfs-entry-path :test #'equal)))
+
                   (unless (and (boundp 'gptel-track-media) gptel-track-media)
                     (error "gptel media send option is off (gptel-track-media is nil)"))
-                  
+
                   (unless (or in-vfs (file-exists-p abs-path))
-                    (error "Cannot read media. The file does not exist in VFS or on disk at: %s" abs-path))
-                  
+                    (error "Cannot read media. The file does not exist in VFS or on disk \
+at: %s" abs-path))
+
                   (let* ((mime (mailcap-file-name-to-mime-type abs-path))
                          (info (when (bound-and-true-p macher-agent--active-fsm)
-                                 (macher-agent--extract-fsm-info macher-agent--active-fsm)))
-                         (session (when info (plist-get info :macher-agent-session))))
+                                 (macher-agent--extract-fsm-info macher-agent--active-fsm))))
                     (unless mime
                       (error "Could not determine MIME type for media: %s" abs-path))
-                    
-                    (unless session
-                      (setq session (make-macher-agent-session :id (buffer-name) :workspace workspace))
-                      (when (and info (bound-and-true-p macher-agent--active-fsm))
-                        (setf (gptel-fsm-info macher-agent--active-fsm) (plist-put info :macher-agent-session session))))
-                    
+
                     (let ((base64-str
                            (with-temp-buffer
                              (set-buffer-multibyte nil)
@@ -42,8 +45,16 @@
                                (insert-file-contents-literally abs-path))
                              (base64-encode-region (point-min) (point-max) t)
                              (buffer-string))))
-                      (setf (macher-agent-session-pending-media session)
-                            (list (list base64-str :mime mime))))
-                    
-                    (make-macher-agent-lisp-result-response 
-                     :payload (format "SUCCESS: Media '%s' has been successfully read and attached to this response. You may now analyse it immediately." actual-name))))))
+                      (when context
+                        (let ((pending
+                               (macher-agent--get-context-data context :pending-media)))
+                          (setq pending (append pending (list (list base64-str :mime mime))))
+                          (macher-agent--set-context-data context :pending-media pending)
+                          (when info
+                            (unless (plist-get info :macher-agent-context)
+                              (setf (gptel-fsm-info macher-agent--active-fsm)
+                                    (plist-put info :macher-agent-context context)))))))
+
+                    (make-macher-agent-lisp-result-response
+                     :payload (format "SUCCESS: Media '%s' has been successfully read and \
+attached to this response. You may now analyse it immediately." actual-name))))))

--- a/skills/scripts/search_in_workspace.el
+++ b/skills/scripts/search_in_workspace.el
@@ -1,19 +1,19 @@
 (macher-agent-make-tool macher-agent-search-in-workspace-tool
-                        "Search for a regular expression pattern within the strictly bounded workspace."
-                        :category "ro"
-                        :args '((:name "pattern" :type string :description "The regex pattern to search for"))
-                        :command-fn (lambda (payload context _root)
-                                      (let ((pattern (plist-get payload :pattern)))
-                                        (if (or (string-empty-p (string-trim pattern))
-                                                (string-equal pattern ".*")
-                                                (string-match-p "^\\s-*$" pattern))
-                                            (error "Regex pattern too broad. Provide a more specific search term.")
-                                          (let ((output ""))
-                                            ;; 1. Boot up the VFS sandbox (rsync + live buffer overlay)
-                                            (macher-agent-with-strict-vfs-pipeline context
-                                                                                   ;; 2. Run ripgrep inside the sandbox where default-directory is bound
-                                                                                   (let ((cmd (format "rg --line-number --color=never --max-columns=150 '%s' . || echo 'No matches found.'" 
-                                                                                                      (replace-regexp-in-string "'" "'\\''" pattern))))
-                                                                                     (setq output (shell-command-to-string cmd))))
-                                            ;; 3. Return the evaluated text to the agent, not a background process
-                                            (make-macher-agent-lisp-result-response :payload output))))))
+    "Search for a regular expression pattern within the strictly bounded workspace."
+  :category "ro"
+  :args '((:name "pattern" :type string :description "The regex pattern to search for"))
+  :command-fn (lambda (payload context _root)
+                (if-let* ((pattern (plist-get payload :pattern))
+                          (trimmed (string-trim pattern))
+                          ((not (string-empty-p trimmed)))
+                          ((not (string-equal trimmed ".*")))
+                          ((not (string-match-p "^\\s-*$" trimmed))))
+                    (let ((output ""))
+                      (macher-agent-with-strict-vfs-pipeline context
+                                                             (let ((cmd (format "rg \
+--line-number --color=never --max-columns=150 '%s' . || echo 'No matches found.'" 
+                                                                                (replace-regexp-in-string "'" "'\\''" trimmed))))
+                                                               (setq output
+                                                                     (shell-command-to-string cmd))))
+                      (make-macher-agent-lisp-result-response :payload output))
+                  (error "Regex pattern too broad. Provide a more specific search term."))))

--- a/skills/scripts/spawn_subagent.el
+++ b/skills/scripts/spawn_subagent.el
@@ -2,16 +2,12 @@
     "Spawn a new sub-agent buffer to handle delegated work."
   :category "orchestrate"
   :args '((:name "name" :type string)
-          (:name "presets" :type array :items (:type string) :description "Array of SKILL.md presets to apply" :optional t))
-  :command-fn (lambda (payload)
+          (:name "presets" :type array :items (:type string) :description "Array of \
+SKILL.md presets to apply" :optional t))
+  :command-fn (lambda (payload context root)
                 (let* ((name (plist-get payload :name))
-                       (raw-presets (plist-get payload :presets))
-                       (preset-list (cond ((vectorp raw-presets) (append raw-presets nil))
-                                          ((stringp raw-presets) (list raw-presets))
-                                          ((listp raw-presets) raw-presets)
-                                          (t nil)))
-                       (context (ignore-errors (macher-agent-resolve-context)))
-                       (dir default-directory)
-                       (buf (macher-agent-add-subagent name dir nil context preset-list)))
-                  (make-macher-agent-lisp-result-response 
-                   :payload (format "SUCCESS: Sub-agent created. The EXACT buffer name to use is '%s'." (buffer-name buf))))))
+                       (preset-list (append (plist-get payload :presets) nil))
+                       (buf (macher-agent-add-subagent name root nil context preset-list)))
+                  (make-macher-agent-lisp-result-response
+                   :payload (format "SUCCESS: Sub-agent created. The EXACT buffer name to \
+use is '%s'." (buffer-name buf))))))

--- a/skills/scripts/submit_task_result.el
+++ b/skills/scripts/submit_task_result.el
@@ -1,22 +1,20 @@
 (macher-agent-make-tool macher-agent-submit-task-result-tool
-                        "Submit the final result of your assigned task back to the orchestrator."
-                        :category "worker"
-                        :args '((:name "final_answer" :type string :description "The final answer, data, or summary of completed work."))
-                        :command-fn (lambda (payload)
-                                      (let* ((final_answer (plist-get payload :final_answer))
-                                             (worker-id (buffer-name (current-buffer))))
-                                        
-                                        ;; Synchronously hand the result back to the parent
-                                        (when (boundp 'macher-agent--parent-callback)
-                                          (funcall macher-agent--parent-callback 
-                                                   ;; FIX: Yield the struct, not a plist
-                                                   (make-macher-agent-tool-response 
-                                                    :status 'success 
-                                                    :data final_answer 
-                                                    :buffer-name worker-id)))
-                                        
-                                        ;; Flag the buffer so the global idle timer knows it's safe to reap
-                                        (setq-local macher-agent-task-finished t)
-                                        
-                                        (make-macher-agent-lisp-result-response 
-                                         :payload "SUCCESS: Result submitted."))))
+    "Submit the final result of your assigned task back to the orchestrator."
+  :category "worker"
+  :args '((:name "final_answer" :type string :description "The final answer, data, or \
+summary of completed work."))
+  :command-fn (lambda (payload _context _root)
+                (when-let* ((final_answer (plist-get payload :final_answer))
+                            ((boundp 'macher-agent--parent-callback))
+                            (callback macher-agent--parent-callback))
+
+                  (funcall callback
+                           (make-macher-agent-tool-response
+                            :status 'success
+                            :data final_answer
+                            :buffer-name (buffer-name (current-buffer))))
+
+                  (setq-local macher-agent-task-finished t)
+
+                  (make-macher-agent-lisp-result-response
+                   :payload "SUCCESS: Result submitted."))))

--- a/skills/scripts/wait_for_vfs_semaphore.el
+++ b/skills/scripts/wait_for_vfs_semaphore.el
@@ -1,5 +1,6 @@
 (macher-agent-make-tool macher-agent-wait-for-vfs-semaphore
-    "Suspends the agent until the specified file is created or modified in the virtual file system."
+    "Suspends the agent until the specified file is created or modified in the virtual \
+file system."
   :category "worker"
   :args '((:name "path" :type string :description "File path to monitor"))
   :command-fn (lambda (payload context _root)

--- a/skills/scripts/write_buffer_in_workspace.el
+++ b/skills/scripts/write_buffer_in_workspace.el
@@ -1,19 +1,16 @@
 (macher-agent-make-tool macher-agent-write-buffer-in-workspace-tool
-  "Propose new content for a live Emacs buffer. This creates a virtual patch that will be presented for review rather than mutating the buffer immediately."
+    "Propose new content for a live Emacs buffer. This creates a virtual patch that will \
+be presented for review rather than mutating the buffer immediately."
   :category "workspace"
   :args '((:name "buffer_name" :type string :description "The name of the target buffer")
-          (:name "content" :type string :description "The proposed new content for the buffer"))
+          (:name "content" :type string :description "The proposed new content for the \
+buffer"))
   :command-fn (lambda (payload context _root)
-                (let* ((buffer_name (plist-get payload :buffer_name))
-                       (content (plist-get payload :content))
-                       (actual-name (macher-agent--resolve-buffer-name buffer_name)))
-                  
-                  (unless (stringp buffer_name)
-                    (error "Wrong type argument: stringp, %s" buffer_name))
-                  (unless (stringp content)
-                    (error "Wrong type argument: stringp, %s" content))
-
+                (when-let* ((buffer_name (plist-get payload :buffer_name))
+                            (content (plist-get payload :content))
+                            (actual-name (macher-agent--resolve-buffer-name buffer_name)))
                   (when context
                     (macher-agent--update-context-file context actual-name content))
-                  
-                  (make-macher-agent-lisp-result-response :payload (format "SUCCESS: Virtual edit recorded for buffer '%s'. A patch will be generated at the end of the turn." actual-name)))))
+                  (make-macher-agent-lisp-result-response :payload (format "SUCCESS: \
+Virtual edit recorded for buffer '%s'. A patch will be generated at the end of the \
+turn." actual-name)))))

--- a/tests/macher-agent-core-test.el
+++ b/tests/macher-agent-core-test.el
@@ -19,9 +19,11 @@
           (describe "1. VFS and Optimistic Concurrency"
                     (it "asserts that a VFS write is rejected if the underlying file has drifted"
                         (let* ((workspace (make-macher-agent-workspace :project-root "/mock/proj/"))
+                               (ctx (macher--make-context :workspace workspace :contents nil))
                                (file-path "/mock/proj/test.el")
                                (original-mtime '(25000 12345))
                                (drifted-mtime '(25000 99999)))
+                          (puthash (expand-file-name "/mock/proj/") ctx macher-agent-active-workspaces)
                           
                           ;; Initialise tracking
                           (puthash file-path original-mtime (macher-agent-workspace-mtime-tracker workspace))
@@ -43,23 +45,24 @@
 
                     (it "asserts that different agent sessions within the same workspace share uncommitted VFS state"
                         (let* ((workspace (make-macher-agent-workspace :project-root "/mock/proj/"))
-                               (session-a (make-macher-agent-session :id "Agent-A" :workspace workspace))
-                               (session-b (make-macher-agent-session :id "Agent-B" :workspace workspace))
+                               (ctx-a (macher--make-context :workspace workspace :contents nil))
+                               (ctx-b (macher--make-context :workspace workspace :contents nil))
                                (file-path "/mock/proj/shared.el"))
+                          (puthash (expand-file-name "/mock/proj/") ctx-a macher-agent-active-workspaces)
                           
                           ;; Agent A writes to the shared VFS
-                          (macher-agent-vfs-write (macher-agent-session-workspace session-a) file-path "Agent A changes")
+                          (macher-agent-vfs-write workspace file-path "Agent A changes")
                           
                           ;; Agent B reads from the shared VFS
-                          (let ((read-content (macher-agent-vfs-read (macher-agent-session-workspace session-b) file-path)))
+                          (let ((read-content (macher-agent-vfs-read workspace file-path)))
                             (expect read-content :to-equal "Agent A changes")))))
 
           (describe "2. Execution Environments (Sandbox)"
                     (it "asserts that sandbox inflation overlays the uncommitted VFS changes"
                         (let* ((workspace (make-macher-agent-workspace :project-root "/mock/proj/"))
-                               (session (make-macher-agent-session :id "Agent-A" 
-                                                                   :workspace workspace
-                                                                   :sandbox-path "/tmp/macher-sandbox/")))
+                               (ctx (macher--make-context :workspace workspace :contents nil)))
+                          (macher-agent--set-context-data ctx :sandbox-path "/tmp/macher-sandbox/")
+                          (puthash (expand-file-name "/mock/proj/") ctx macher-agent-active-workspaces)
                           
                           (puthash "/mock/proj/overlay.el" "VFS Overlay Content" (macher-agent-workspace-vfs-buffers workspace))
                           
@@ -70,18 +73,18 @@
                                       (when (string-suffix-p "overlay.el" filename)
                                         (setq written-to-sandbox (substring-no-properties start end)))))
                             
-                            (macher-agent-sandbox-inflate session)
+                            (macher-agent-sandbox-inflate ctx)
                             
                             (expect written-to-sandbox :to-equal "VFS Overlay Content")))))
 
           (describe "3. Context and Isolation (Lexical Survival)"
                     (it "asserts that lexical context survives async gptel callbacks without buffer bleeding"
                         (let* ((workspace (make-macher-agent-workspace :project-root "/mock/proj/"))
-                               (session (make-macher-agent-session :id "Agent-A" :workspace workspace))
-                               (fsm 'mock-fsm)
+                               (ctx (macher--make-context :workspace workspace :contents nil))
+                               (fsm (gptel-make-fsm))
                                (executed-workspace nil))
                           
-                          (spy-on 'gptel-fsm-info :and-return-value (list :macher-agent-session session))
+                          (setf (gptel-fsm-info fsm) (list :macher-agent-context ctx))
                           
                           ;; Mock the behaviour where current-buffer changes asynchronously
                           (with-temp-buffer
@@ -90,21 +93,21 @@
                               ;; Execute a mock async tool callback
                               (with-temp-buffer ;; "Wandering" buffer context
                                 (let* ((info (macher-agent--extract-fsm-info fsm))
-                                       (fsm-session (plist-get info :macher-agent-session)))
-                                  (when fsm-session
-                                    (setq executed-workspace (macher-agent-session-workspace fsm-session)))))
+                                       (fsm-ctx (plist-get info :macher-agent-context)))
+                                  (when fsm-ctx
+                                    (setq executed-workspace (macher-agent--get-context-workspace fsm-ctx)))))
                               
                               (expect executed-workspace :to-be workspace))))))
 
           (describe "4. Media Injection Isolation"
                     (it "asserts that media injection strictly checks FSM properties"
                         (let* ((workspace (make-macher-agent-workspace :project-root "/mock/proj/"))
-                               (session (make-macher-agent-session :workspace workspace))
-                               (fsm 'mock-fsm)
+                               (ctx (macher--make-context :workspace workspace :contents nil))
+                               (fsm (gptel-make-fsm))
                                (macher-agent--active-fsm fsm))
                           
-                          (spy-on 'gptel-fsm-info :and-return-value (list :macher-agent-session session))
-                          (setf (macher-agent-session-pending-media session) (list (list "mockbase64" :mime "image/png")))
+                          (setf (gptel-fsm-info fsm) (list :macher-agent-context ctx))
+                          (macher-agent--set-context-data ctx :pending-media (list (list "mockbase64" :mime "image/png")))
                           
                           (spy-on 'gptel--inject-media :and-return-value nil)
                           (spy-on 'gptel--inject-prompt :and-return-value nil)
@@ -112,7 +115,7 @@
                           (macher-agent--inject-media-fsm-advice (lambda (f) f) fsm)
                           
                           (expect 'gptel--inject-media :to-have-been-called)
-                          (expect (macher-agent-session-pending-media session) :to-be nil))))
+                          (expect (macher-agent--get-context-data ctx :pending-media) :to-be nil))))
 
           (describe "5. Diff Splitting Behaviour"
                     (it "asserts that virtual buffer modifications are split from physical file modifications"
@@ -120,10 +123,10 @@
                                (context (macher--make-context :workspace (cons 'project "/mock/proj/")
                                                               :contents (list (macher-agent-vfs-make-entry "/mock/proj/disk-file.el" "old" "new")
                                                                               (macher-agent-vfs-make-entry "*scratch*" "old" "new"))))
-                               (fsm 'mock-fsm))
+                               (fsm (gptel-make-fsm)))
                           
                           (spy-on 'macher-agent-resolve-context :and-return-value context)
-                          (spy-on 'gptel-fsm-info :and-return-value (list :macher-agent-session (make-macher-agent-session :workspace workspace)))
+                          (setf (gptel-fsm-info fsm) (list :macher-agent-context context))
                           (setf (macher-context-dirty-p context) t)
                           
                           ;; Spy on upstream Emacs UI commands to prevent actual buffers from rendering
@@ -131,12 +134,11 @@
                           (spy-on 'macher--get-buffer :and-return-value (list (get-buffer-create "*patch*")))
                           
                           (let ((orig-called-with nil))
-                            ;; Execute our bridge interceptor, mocking the core function to capture the splits
-                            (macher-agent--override-build-patch 
-                             (lambda (ctx _fsm) 
-                               (push (macher-context-contents ctx) orig-called-with)
-                               (run-hooks 'macher-patch-ready-hook))
-                             context fsm)
+                            (spy-on 'macher--build-patch :and-call-fake
+                                    (lambda (ctx _fsm)
+                                      (push (macher-context-contents ctx) orig-called-with)
+                                      (run-hooks 'macher-patch-ready-hook)))
+                            (macher-agent-process-request context fsm)
                             
                             ;; Assert that the core patch builder was called twice
                             (expect (length orig-called-with) :to-equal 2)

--- a/tests/macher-agent-full-integration-test.el
+++ b/tests/macher-agent-full-integration-test.el
@@ -1,0 +1,226 @@
+;;; macher-agent-full-integration-test.el --- Full integration tests for macher-agent -*- lexical-binding: t -*-
+
+(require 'buttercup)
+(require 'cl-lib)
+(require 'gptel)
+(require 'macher-agent)
+
+(defmacro with-macher-agent-test-context (routing-alist call-counter &rest body)
+  "Execute BODY with gptel's network requests mocked according to ROUTING-ALIST.
+ROUTING-ALIST maps buffer name substrings to a list of mock response plists.
+CALL-COUNTER is a symbol bound in the calling environment that increments upon FSM completion."
+  (declare (indent 2))
+  `(let* ((queues (copy-tree ,routing-alist))
+          (ws (make-macher-agent-workspace :project-root default-directory))
+          (ctx (macher-agent--make-vfs-context :workspace ws :contents nil)))
+
+     ;; 1. Initialise workspace, register persistent context and load skills into the registry
+     (setq-local macher-agent--persistent-context ctx)
+     (puthash (expand-file-name default-directory) ctx macher-agent-active-workspaces)
+     (puthash (expand-file-name (macher-agent-root default-directory)) ctx macher-agent-active-workspaces)
+     (macher-agent-initialize-skills
+      ctx (or (bound-and-true-p macher-agent--bundled-skills-dir)
+              (bound-and-true-p macher-agent-bundled-skills-directory)))
+
+     ;; 2. Configure FSM mock and execute body
+     (let ((gptel-use-curl nil)
+           (gptel-confirm-tool-calls nil)
+           (gptel-backend (gptel-make-openai "Mock" :key "mock-key" :models '(mock-model)))
+           (gptel-model 'mock-model)
+           (gptel-tools (hash-table-values (macher-agent-workspace-tools-registry ws))))
+
+       (cl-letf (((symbol-function 'gptel--url-get-response)
+                  (lambda (fsm)
+                    (let* ((info (gptel-fsm-info fsm))
+                           (callback (or (plist-get info :callback) #'gptel--insert-response))
+                           (current-buf (buffer-name (plist-get info :buffer)))
+                           ;; Match queue by substring and pop the next sequenced response
+                           (queue-pair (cl-find-if (lambda (pair) (string-match-p (car pair) current-buf)) queues))
+                           (resp (and queue-pair (pop (cdr queue-pair)))))
+
+                      (plist-put info :macher-agent-context ctx)
+
+                      ;; Run asynchronously to process background tool queues
+                      (run-at-time 0.01 nil
+                                   (lambda ()
+                                     (plist-put info :http-status "200")
+                                     (plist-put info :status "200 OK")
+                                     (gptel--fsm-transition fsm) ;; WAIT -> TYPE
+
+                                     (if resp
+                                         (progn
+                                           (when (plist-get resp :tool-use)
+                                             ;; Dynamically map our positional mock values to the correct 
+                                             ;; schema keys declared by the tool.
+                                             (let ((tool-use-list nil))
+                                               (cl-loop for tool-req in (plist-get resp :tool-use)
+                                                        for i from 1
+                                                        do
+                                                        (let* ((tool-name (car tool-req))
+                                                               (tool-vals (cdr tool-req))
+                                                               (tool-spec (cl-find-if (lambda (ts) (equal (gptel-tool-name ts) tool-name))
+                                                                                      (plist-get info :tools)))
+                                                               (expected-args (gptel-tool-args tool-spec))
+                                                               (args-plist nil))
+                                                          (cl-loop for arg in expected-args
+                                                                   for val in tool-vals
+                                                                   do (setq args-plist (plist-put args-plist (intern (concat ":" (if (symbolp (plist-get arg :name)) (symbol-name (plist-get arg :name)) (plist-get arg :name)))) val)))
+                                                          (push (list :id (format "call_%s_%d" current-buf i)
+                                                                      :name tool-name
+                                                                      :args args-plist)
+                                                                tool-use-list)))
+                                               (plist-put info :tool-use (nreverse tool-use-list))))
+
+                                           (if (plist-get resp :text)
+                                               (funcall callback (plist-get resp :text) info)
+                                             (funcall callback nil info)))
+                                       (funcall callback "Fallback mock response." info))
+
+                                     (gptel--fsm-transition fsm) ;; TYPE -> TOOL or DONE
+                                     (cl-incf ,call-counter))))))
+                 ;; Map curl fetcher to the exact same mock to guarantee coverage
+                 ((symbol-function 'gptel-curl-get-response)
+                  (symbol-function 'gptel--url-get-response)))
+         ,@body))))
+
+(describe "Macher Agent Integration"
+
+          (it "spawns sub-agents, delegates tasks, and concatenates responses via actual tool execution"
+              (let ((call-count 0)
+                    (parent-buffer (generate-new-buffer "*macher-test-parent*")))
+                (unwind-protect
+                    (with-current-buffer parent-buffer
+                      (when (fboundp 'markdown-mode) (markdown-mode))
+                      (when (fboundp 'gptel-mode) (gptel-mode 1))
+                      (when (fboundp 'macher-agent-mode) (macher-agent-mode 1))
+
+                      (insert "Delegate the data processing task to two sub-agents.")
+
+                      (with-macher-agent-test-context
+                       '(("macher-test-parent" .
+                          ((:text nil :tool-use (("spawn_subagent" "subagent-1")
+                                                 ("spawn_subagent" "subagent-2")
+                                                 ("delegate_tasks_to_subagents"
+                                                  [(:buffer_name "subagent-1" :instructions "Process part A") 
+                                                   (:buffer_name "subagent-2" :instructions "Process part B")])))
+                           (:text "Processed data part A and Processed data part B." :tool-use nil)))
+                         ("subagent-1" .
+                          ((:text nil :tool-use (("submit_task_result" "Processed data part A.")))))
+                         ("subagent-2" .
+                          ((:text nil :tool-use (("submit_task_result" "Processed data part B."))))))
+                       call-count
+
+                       (if (fboundp 'macher-agent-send)
+                           (funcall (symbol-function 'macher-agent-send))
+                         (gptel-send))
+
+                       (let ((timeout 100))
+                         (while (and (< call-count 4) (> timeout 0))
+                           (accept-process-output nil 0.05)
+                           (cl-decf timeout)))
+
+                       (expect (>= call-count 4) :to-be t)
+                       (expect (buffer-string) :to-match "Processed data part A and Processed data part B.")
+
+                       (let ((s1 (get-buffer "subagent-1"))
+                             (s2 (get-buffer "subagent-2")))
+                         (expect s1 :not :to-be nil)
+                         (expect s2 :not :to-be nil)
+                         (when s1
+                           (with-current-buffer s1
+                             (expect (buffer-string) :to-match "Process part A")))
+                         (when s2
+                           (with-current-buffer s2
+                             (expect (buffer-string) :to-match "Process part B"))))))
+
+                  (when (buffer-live-p parent-buffer) (kill-buffer parent-buffer))
+                  (when (get-buffer "subagent-1") (kill-buffer "subagent-1"))
+                  (when (get-buffer "subagent-2") (kill-buffer "subagent-2")))))
+
+          (it "writes text to a workspace buffer and reads it back"
+              (let ((call-count 0)
+                    (parent-buffer (generate-new-buffer "*macher-test-rw*")))
+                (unwind-protect
+                    (with-current-buffer parent-buffer
+                      (when (fboundp 'markdown-mode) (markdown-mode))
+                      (when (fboundp 'gptel-mode) (gptel-mode 1))
+                      (when (fboundp 'macher-agent-mode) (macher-agent-mode 1))
+
+                      (insert "Write 'Hello Workspace' to target-buffer and read it back.")
+
+                      (with-macher-agent-test-context
+                       '(("macher-test-rw" .
+                          ((:text nil :tool-use (("write_buffer_in_workspace" "target-buffer" "Hello Workspace")))
+                           (:text nil :tool-use (("read_buffer_in_workspace" "target-buffer")))
+                           (:text "Final output: Hello Workspace" :tool-use nil))))
+                       call-count
+
+                       (if (fboundp 'macher-agent-send)
+                           (funcall (symbol-function 'macher-agent-send))
+                         (gptel-send))
+
+                       (let ((timeout 100))
+                         (while (and (< call-count 3) (> timeout 0))
+                           (accept-process-output nil 0.05)
+                           (cl-decf timeout)))
+
+                       (expect (>= call-count 3) :to-be t)
+                       (expect (buffer-string) :to-match "Final output: Hello Workspace")
+
+                       (let ((vfs-entry (cl-find "target-buffer" (macher-agent--get-context-contents ctx)
+                                                 :key #'car :test #'equal)))
+                         (expect vfs-entry :not :to-be nil)
+                         (when vfs-entry
+                           (expect (macher-agent-vfs-entry-curr vfs-entry) :to-equal "Hello Workspace")))))
+
+                  (when (buffer-live-p parent-buffer) (kill-buffer parent-buffer)))))
+
+          (it "inflates virtual workspace edits into the physical sandbox directory for tool execution"
+              (let ((call-count 0)
+                    (sandbox-dir (make-temp-file "test-integration-sandbox-" t))
+                    (parent-buffer (generate-new-buffer "*macher-test-sandbox-inflate*")))
+                (unwind-protect
+                    (with-current-buffer parent-buffer
+                      (when (fboundp 'markdown-mode) (markdown-mode))
+                      (when (fboundp 'gptel-mode) (gptel-mode 1))
+                      (when (fboundp 'macher-agent-mode) (macher-agent-mode 1))
+
+                      (insert "Write file via workspace tool and check sandbox inflation.")
+
+                      (with-macher-agent-test-context
+                       '(("macher-test-sandbox-inflate" .
+                          ((:text nil :tool-use (("write_buffer_in_workspace" "sandbox_test.txt" "sandbox inflated content")))
+                           (:text "Sandbox write verified." :tool-use nil))))
+                       call-count
+
+                       (macher-agent--set-context-data ctx :sandbox-path sandbox-dir)
+
+                       (if (fboundp 'macher-agent-send)
+                           (funcall (symbol-function 'macher-agent-send))
+                         (gptel-send))
+
+                       (let ((timeout 100))
+                         (while (and (< call-count 2) (> timeout 0))
+                           (accept-process-output nil 0.05)
+                           (cl-decf timeout)))
+
+                       (expect (>= call-count 2) :to-be t)
+
+                       (let ((vfs-entry (cl-find "sandbox_test.txt" (macher-agent--get-context-contents ctx)
+                                                 :key #'car :test #'equal)))
+                         (expect vfs-entry :not :to-be nil)
+                         (expect (macher-agent-vfs-entry-curr vfs-entry) :to-equal "sandbox inflated content"))
+
+                       (macher-agent-sandbox-inflate ctx)
+                       (let ((sandbox-file (expand-file-name "sandbox_test.txt" sandbox-dir)))
+                         (expect (file-exists-p sandbox-file) :to-be t)
+                         (when (file-exists-p sandbox-file)
+                           (with-temp-buffer
+                             (insert-file-contents sandbox-file)
+                             (expect (buffer-string) :to-equal "sandbox inflated content"))))))
+
+                  (when (buffer-live-p parent-buffer) (kill-buffer parent-buffer))
+                  (when (file-exists-p sandbox-dir) (delete-directory sandbox-dir t))))))
+
+(provide 'macher-agent-full-integration-test)
+;;; macher-agent-full-integration-test.el ends here

--- a/tests/macher-agent-integration-test.el
+++ b/tests/macher-agent-integration-test.el
@@ -1,4 +1,5 @@
 ;;; macher-agent-integration-test.el --- Tests for macher-agent-skills -*- lexical-binding: t -*-
+
 (require 'buttercup)
 (require 'macher-agent-macher-bridge)
 (require 'macher-agent)
@@ -21,7 +22,9 @@
           (before-each
            (setq macher-agent--garbage-queue nil)
            (spy-on 'macher-agent-resolve-context :and-return-value
-                   (let ((ctx (macher-agent--make-vfs-context :workspace (cons 'agent (make-macher-agent-workspace :project-root "/mock/proj")) :contents nil)))
+                   (let* ((ws (make-macher-agent-workspace :project-root "/mock/proj"))
+                          (ctx (macher-agent--make-vfs-context :workspace ws :contents nil)))
+                     (puthash (expand-file-name "/mock/proj") ctx macher-agent-active-workspaces)
                      (macher-agent-initialize-skills ctx (or (bound-and-true-p macher-agent--bundled-skills-dir) macher-agent-bundled-skills-directory))
                      ctx))
            
@@ -68,10 +71,10 @@
                       (let ((spawn-fn (gptel-tool-function spawn-tool)))
                         (if (gptel-tool-async spawn-tool)
                             (progn
-                              (funcall spawn-fn "agent-france" (lambda (res) (setq final-result (cons 'spawn1 res))))
-                              (funcall spawn-fn "agent-spain" (lambda (res) (setq final-result (cons 'spawn2 res)))))
-                          (funcall spawn-fn "agent-france")
-                          (funcall spawn-fn "agent-spain")))
+                              (funcall spawn-fn (lambda (res) (setq final-result (cons 'spawn1 res))) "agent-france")
+                              (funcall spawn-fn (lambda (res) (setq final-result (cons 'spawn2 res))) "agent-spain"))
+                          (funcall spawn-fn nil "agent-france")
+                          (funcall spawn-fn nil "agent-spain")))
 
                       (unless (buffer-live-p (get-buffer "agent-france"))
                         (error "SPAWN FAILED! final-result=%S spawn-tool=%S" final-result spawn-tool))
@@ -90,9 +93,9 @@
                             (delegate-fn (gptel-tool-function delegate-tool)))
                         
                         (funcall delegate-fn
-                                 tasks
                                  (lambda (result)
-                                   (setq final-result result))))
+                                   (setq final-result result))
+                                 tasks))
 
                       ;; --- D. Assertions ---
                       (expect final-result :to-be-truthy)

--- a/tests/macher-agent-skills-test.el
+++ b/tests/macher-agent-skills-test.el
@@ -1,316 +1,319 @@
 ;;; macher-agent-skills-test.el --- Tests for macher-agent-skills -*- lexical-binding: t -*-
+
 (require 'buttercup)
 (require 'macher-agent-macher-bridge)
 (require 'macher-agent)
 
 (describe "macher-agent-skills"
 
-  (describe "Orchestration Tools (skills/scripts/*.el)"
-    (before-all
-      ;; Load all tool scripts to define their variables for testing
-      (dolist (script (directory-files "skills/scripts" t "\\.el$"))
-        (with-temp-buffer
-          (insert-file-contents script)
-          (let ((val nil))
-            (condition-case nil
-                (while t (setq val (eval (read (current-buffer)) t)))
-              (end-of-file val))))))
-    (it "guarantees list_buffers_in_workspace output perfectly matches context-tree buffer categorisation"
-      (let* ((ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "*pure-buffer*" "" "")
-                                                        (macher-agent-vfs-make-entry "/external/path.txt" "" "")
-                                                        (macher-agent-vfs-make-entry "/root/internal.txt" "" ""))))
-             (list-tool-fn (gptel-tool-function macher-agent-list-buffers-in-workspace-tool)))
+          (describe "Orchestration Tools (skills/scripts/*.el)"
+                    (before-all
+                     ;; Load all tool scripts to define their variables for testing
+                     (dolist (script (directory-files "skills/scripts" t "\\.el$"))
+                       (with-temp-buffer
+                         (insert-file-contents script)
+                         (let ((val nil))
+                           (condition-case nil
+                               (while t (setq val (eval (read (current-buffer)) t)))
+                             (end-of-file val))))))
+                    (it "guarantees list_buffers_in_workspace output perfectly matches context-tree buffer categorisation"
+                        (let* ((ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "*pure-buffer*" "" "")
+                                                                          (macher-agent-vfs-make-entry "/external/path.txt" "" "")
+                                                                          (macher-agent-vfs-make-entry "/root/internal.txt" "" ""))))
+                               (list-tool-fn (gptel-tool-function macher-agent-list-buffers-in-workspace-tool)))
 
-        (spy-on 'macher-agent-resolve-context :and-return-value ctx)
-        (spy-on 'macher-agent-context-classify-entry :and-call-fake
-                (lambda (path &rest _)
-                  (pcase path
-                    ("*pure-buffer*" 'buffer)
-                    ("/external/path.txt" 'external)
-                    ("/root/internal.txt" 'file))))
+                          (spy-on 'macher-agent-resolve-context :and-return-value ctx)
+                          (spy-on 'macher-agent-context-classify-entry :and-call-fake
+                                  (lambda (path &rest _)
+                                    (pcase path
+                                      ("*pure-buffer*" 'buffer)
+                                      ("/external/path.txt" 'external)
+                                      ("/root/internal.txt" 'file))))
 
-        (let ((result (funcall list-tool-fn)))
-          (expect result :to-match "\\*pure-buffer\\*")
-          (expect result :to-match "/external/path\\.txt")
-          (expect result :not :to-match "internal\\.txt"))))
-    (it "properly parses a JSON string into a vector for task delegation"
-      (let* ((callback-called nil)
-             (callback (lambda (res) (setq callback-called res)))
-             (json-tasks (vector (list :buffer_name "test-sub" :instructions "do work")))
-             (tool-fn (gptel-tool-function macher-agent-delegate-tasks-to-subagents-tool))
-             (buf (get-buffer-create "test-sub")))
-        
-        (spy-on 'macher-agent-resolve-context :and-return-value (macher--make-context))
-        (spy-on 'macher-agent-execute-parallel)
-        (spy-on 'macher-agent--prepare-subagent-instructions)
-        (spy-on 'macher-agent--ensure-access)
-        
-        (funcall tool-fn json-tasks callback)
-        
-        (expect 'macher-agent-execute-parallel :to-have-been-called)
-        (kill-buffer buf)))
+                          (let ((result (funcall list-tool-fn nil)))
+                            (expect result :to-match "\\*pure-buffer\\*")
+                            (expect result :to-match "/external/path\\.txt")
+                            (expect result :not :to-match "internal\\.txt"))))
+                    (it "properly parses a JSON string into a vector for task delegation"
+                        (let* ((callback-called nil)
+                               (callback (lambda (res) (setq callback-called res)))
+                               (json-tasks (vector (list :buffer_name "test-sub" :instructions "do work")))
+                               (tool-fn (gptel-tool-function macher-agent-delegate-tasks-to-subagents-tool))
+                               (buf (get-buffer-create "test-sub")))
+                          
+                          (spy-on 'macher-agent-resolve-context :and-return-value (macher--make-context))
+                          (spy-on 'macher-agent-execute-parallel)
+                          (spy-on 'macher-agent--prepare-subagent-instructions)
+                          (spy-on 'macher-agent--ensure-access)
+                          
+                          (funcall tool-fn callback json-tasks)
+                          
+                          (expect 'macher-agent-execute-parallel :to-have-been-called)
+                          (kill-buffer buf)))
 
-    (it "reports an error if gptel-send aborts or fails silently"
-      (let* ((buf (generate-new-buffer "*macher-agent: worker*"))
-             (callback-called nil)
-             (callback (lambda (msg) (setq callback-called msg))))
+                    (it "reports an error if gptel-send aborts or fails silently"
+                        (let* ((buf (generate-new-buffer "*macher-agent: worker*"))
+                               (callback-called nil)
+                               (callback (lambda (msg) (setq callback-called msg))))
 
-        (spy-on 'macher-agent-resolve-context :and-return-value (macher--make-context :contents nil))
-        ;; Simulate gptel-send firing and instantly triggering the post-response hook
-        (spy-on 'gptel-send :and-call-fake
-                (lambda ()
-                  (with-current-buffer buf
-                    (run-hook-with-args 'gptel-post-response-functions (point-min) (point-max)))))
+                          (spy-on 'macher-agent-resolve-context :and-return-value (macher--make-context :contents nil))
+                          ;; Simulate gptel-send firing and instantly triggering the post-response hook
+                          (spy-on 'gptel-send :and-call-fake
+                                  (lambda ()
+                                    (with-current-buffer buf
+                                      (run-hook-with-args 'gptel-post-response-functions (point-min) (point-max)))))
 
-        (macher-agent-spawn-task (buffer-name buf) callback)
-        
-        (expect (macher-agent-tool-response-status callback-called) :to-equal 'error)
-        (expect (macher-agent-tool-response-error callback-called) :to-match "stopped silently")
-        (kill-buffer buf)))
+                          (macher-agent-spawn-task (buffer-name buf) callback)
+                          
+                          (expect (macher-agent-tool-response-status callback-called) :to-equal 'error)
+                          (expect (macher-agent-tool-response-error callback-called) :to-match "stopped silently")
+                          (kill-buffer buf)))
 
-    (it "correctly aggregates results from multiple event-driven sub-agents"
-      (let* ((buf1 (generate-new-buffer "worker1"))
-             (buf2 (generate-new-buffer "worker2"))
-             (callback-called nil)
-             (callback (lambda (msg) (setq callback-called msg))))
-        
-        (spy-on 'macher-agent-resolve-context :and-return-value (macher--make-context))
-        ;; Mock the dispatcher to instantly return a success payload rather than firing the network
-        (cl-letf (((symbol-function 'macher-agent-spawn-task)
-                   (lambda (b cb)
-                     (funcall cb (make-macher-agent-tool-response :status 'success :data (format "Output from %s" (buffer-name b)))))))
-          (macher-agent-execute-parallel (list buf1 buf2) callback))
-        
-        (expect (length callback-called) :to-equal 2)
-        (expect (macher-agent-tool-response-status (nth 0 callback-called)) :to-equal 'success)
-        (expect (macher-agent-tool-response-data (nth 0 callback-called)) :to-match "Output from worker1")
-        (expect (macher-agent-tool-response-data (nth 1 callback-called)) :to-match "Output from worker2")
-        (kill-buffer buf1)
-        (kill-buffer buf2)))
+                    (it "correctly aggregates results from multiple event-driven sub-agents"
+                        (let* ((buf1 (generate-new-buffer "worker1"))
+                               (buf2 (generate-new-buffer "worker2"))
+                               (callback-called nil)
+                               (callback (lambda (msg) (setq callback-called msg))))
+                          
+                          (spy-on 'macher-agent-resolve-context :and-return-value (macher--make-context))
+                          ;; Mock the dispatcher to instantly return a success payload rather than firing the network
+                          (cl-letf (((symbol-function 'macher-agent-spawn-task)
+                                     (lambda (b cb)
+                                       (funcall cb (make-macher-agent-tool-response :status 'success :data (format "Output from %s" (buffer-name b)))))))
+                            (macher-agent-execute-parallel (list buf1 buf2) callback))
+                          
+                          (expect (length callback-called) :to-equal 2)
+                          (expect (macher-agent-tool-response-status (nth 0 callback-called)) :to-equal 'success)
+                          (expect (macher-agent-tool-response-data (nth 0 callback-called)) :to-match "Output from worker1")
+                          (expect (macher-agent-tool-response-data (nth 1 callback-called)) :to-match "Output from worker2")
+                          (kill-buffer buf1)
+                          (kill-buffer buf2)))
 
-    (it "ensures target buffer exists when using write_buffer_in_workspace to support patch UI"
-      (let* ((ctx (macher--make-context :contents nil))
-             (tool-fn (gptel-tool-function macher-agent-write-buffer-in-workspace-tool)))
-        (spy-on 'macher-agent-resolve-context :and-return-value ctx)
-        
-        (funcall tool-fn "*new-virtual-asset*" "Ghost content")
-        
-        (expect (cl-find "*new-virtual-asset*" (macher-context-contents ctx) :key #'macher-agent-vfs-entry-path :test #'equal) :not :to-be nil)
-        (let ((contents (cl-find "*new-virtual-asset*" (macher-context-contents ctx) :key #'macher-agent-vfs-entry-path :test #'equal)))
-          (expect (macher-agent-vfs-entry-curr contents) :to-equal "Ghost content"))))
-    
-    (it "rejects fuzzy security matching in read_buffer_in_workspace"
-      (let* ((ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "*scratch*" "" "content"))))
-             (tool-fn (gptel-tool-function macher-agent-read-buffer-in-workspace-tool)))
-        (spy-on 'macher-agent-resolve-context :and-return-value ctx)
-        (let ((result (funcall tool-fn "scratch")))
-          (expect result :to-match "SECURITY ERROR.*scratch.*"))))
+                    (it "ensures target buffer exists when using write_buffer_in_workspace to support patch UI"
+                        (let* ((ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "dummy" "dummy" "dummy"))))
+                               (tool-fn (gptel-tool-function macher-agent-write-buffer-in-workspace-tool)))
+                          (spy-on 'macher-agent-resolve-context :and-return-value ctx)
+                          
+                          (funcall tool-fn nil "*new-virtual-asset*" "Ghost content")
+                          
+                          (expect (cl-find "*new-virtual-asset*" (macher-context-contents ctx) :key #'macher-agent-vfs-entry-path :test #'equal) :not :to-be nil)
+                          (let ((contents (cl-find "*new-virtual-asset*" (macher-context-contents ctx) :key #'macher-agent-vfs-entry-path :test #'equal)))
+                            (expect (macher-agent-vfs-entry-curr contents) :to-equal "Ghost content"))))
+                    
+                    (it "rejects fuzzy security matching in read_buffer_in_workspace"
+                        (let* ((ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "*scratch*" "" "content"))))
+                               (tool-fn (gptel-tool-function macher-agent-read-buffer-in-workspace-tool)))
+                          (spy-on 'macher-agent-resolve-context :and-return-value ctx)
+                          (let ((result (funcall tool-fn nil "scratch")))
+                            (expect result :to-match "SECURITY ERROR.*scratch.*"))))
 
-    (it "submit_task_result triggers parent callback and flags completion"
-      (let* ((buf (generate-new-buffer "worker-buf"))
-             (tool-fn (gptel-tool-function macher-agent-submit-task-result-tool))
-             (callback-data nil))
-        (spy-on 'macher-agent-resolve-context :and-return-value (macher--make-context))
-        (with-current-buffer buf
-          (setq-local macher-agent--parent-callback (lambda (res) (setq callback-data res)))
-          (funcall tool-fn "My final answer")
-          (expect (macher-agent-tool-response-data callback-data) :to-equal "My final answer")
-          (expect macher-agent-task-finished :to-be t))
-        (kill-buffer buf)))
-    
-    (it "write_buffer_in_workspace registers a virtual edit safely"
-      (let* ((ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "test-buf" "orig" "orig"))))
-             (tool-fn (gptel-tool-function macher-agent-write-buffer-in-workspace-tool)))
-        (spy-on 'macher-agent-resolve-context :and-return-value ctx)
-        
-        (let* ((response (funcall tool-fn "test-buf" "New virtual content")))
-          (expect response :to-match "SUCCESS")
-          (expect (macher-context-dirty-p ctx) :to-be t)
-          (expect (macher-agent-vfs-entry-curr (cl-find "test-buf" (macher-context-contents ctx) :key #'macher-agent-vfs-entry-path :test #'equal)) :to-equal "New virtual content"))))
+                    (it "submit_task_result triggers parent callback and flags completion"
+                        (let* ((buf (generate-new-buffer "worker-buf"))
+                               (tool-fn (gptel-tool-function macher-agent-submit-task-result-tool))
+                               (callback-data nil))
+                          (spy-on 'macher-agent-resolve-context :and-return-value (macher--make-context))
+                          (with-current-buffer buf
+                            (setq-local macher-agent--parent-callback (lambda (res) (setq callback-data res)))
+                            (funcall tool-fn nil "My final answer")
+                            (expect (macher-agent-tool-response-data callback-data) :to-equal "My final answer")
+                            (expect macher-agent-task-finished :to-be t))
+                          (kill-buffer buf)))
+                    
+                    (it "write_buffer_in_workspace registers a virtual edit safely"
+                        (let* ((ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "test-buf" "orig" "orig"))))
+                               (tool-fn (gptel-tool-function macher-agent-write-buffer-in-workspace-tool)))
+                          (spy-on 'macher-agent-resolve-context :and-return-value ctx)
+                          
+                          (let* ((response (funcall tool-fn nil "test-buf" "New virtual content")))
+                            (expect response :to-match "SUCCESS")
+                            (expect (macher-context-dirty-p ctx) :to-be t)
+                            (expect (macher-agent-vfs-entry-curr (cl-find "test-buf" (macher-context-contents ctx) :key #'macher-agent-vfs-entry-path :test #'equal)) :to-equal "New virtual content"))))
 
-    (it "multi_edit_buffer_in_workspace uses a decoupled deterministic scratchpad"
-      (let* ((ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "test-file.rs" "line1\nline2" "line1\nline2"))))
-             (tool-fn (gptel-tool-function macher-agent-multi-edit-buffer-in-workspace-tool)))
-        (spy-on 'macher-agent-resolve-context :and-return-value ctx)
-        
-        (let* ((edits (vector (list :old_text "line2" :new_text "line3")))
-               (response (funcall tool-fn "test-file.rs" edits)))
-          (expect response :to-match "SUCCESS")
-          
-          (let ((contents (cl-find "test-file.rs" (macher-context-contents ctx) :key #'macher-agent-vfs-entry-path :test #'equal)))
-            (expect (macher-agent-vfs-entry-curr contents) :to-equal "line1\nline3"))))))
+                    (it "multi_edit_buffer_in_workspace uses a decoupled deterministic scratchpad"
+                        (let* ((ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "test-file.rs" "line1\nline2" "line1\nline2"))))
+                               (tool-fn (gptel-tool-function macher-agent-multi-edit-buffer-in-workspace-tool)))
+                          (spy-on 'macher-agent-resolve-context :and-return-value ctx)
+                          
+                          (let* ((edits (vector (list :old_text "line2" :new_text "line3")))
+                                 (response (funcall tool-fn nil "test-file.rs" edits)))
+                            (expect response :to-match "SUCCESS")
+                            
+                            (let ((contents (cl-find "test-file.rs" (macher-context-contents ctx) :key #'macher-agent-vfs-entry-path :test #'equal)))
+                              (expect (macher-agent-vfs-entry-curr contents) :to-equal "line1\nline3"))))))
 
-  (describe "Agent Skills (macher-agent-skills.el)"
-    (before-each
-      (spy-on 'macher-agent-resolve-context :and-return-value
-              (macher-agent--make-vfs-context :workspace (cons 'agent (make-macher-agent-workspace :project-root "/mock/proj")) :contents nil)))
-    (it "parses SKILL.md files correctly extracting frontmatter and markdown body"
-      (let* ((parsed (macher-agent-parse-skill-file "tests/fixtures/skills/global/SKILL.md")))
-        (expect (plist-get parsed :name) :to-equal "mock-skill")
-        (expect (plist-get parsed :name-sym) :to-equal 'mock-skill)
-        (expect (plist-get parsed :description) :to-equal "A mock skill for testing")
-        (expect (plist-get parsed :allowed-tools) :to-equal '("mock-tool-1" "mock-tool-2"))
-        (expect (plist-get parsed :body) :to-equal "This is the system prompt for the mock skill.\nIt spans multiple lines.")))
+          (describe "Agent Skills (macher-agent-skills.el)"
+                    (before-each
+                     (let* ((ws (make-macher-agent-workspace :project-root "/mock/proj"))
+                            (ctx (macher-agent--make-vfs-context :workspace ws :contents nil)))
+                       (puthash (expand-file-name "/mock/proj") ctx macher-agent-active-workspaces)
+                       (spy-on 'macher-agent-resolve-context :and-return-value ctx)))
+                    (it "parses SKILL.md files correctly extracting frontmatter and markdown body"
+                        (let* ((parsed (macher-agent-parse-skill-file "tests/fixtures/skills/global/SKILL.md")))
+                          (expect (plist-get parsed :name) :to-equal "mock-skill")
+                          (expect (plist-get parsed :name-sym) :to-equal 'mock-skill)
+                          (expect (plist-get parsed :description) :to-equal "A mock skill for testing")
+                          (expect (plist-get parsed :allowed-tools) :to-equal '("mock-tool-1" "mock-tool-2"))
+                          (expect (plist-get parsed :body) :to-equal "This is the system prompt for the mock skill.\nIt spans multiple lines.")))
 
-    (it "prioritises virtual edits inside the VFS when parsing SKILL.md"
-      (let* ((ctx (macher-agent-resolve-context))
-             (vfs-file "tests/fixtures/skills/global/SKILL.md"))
-        (macher-agent--set-context-contents 
-         ctx 
-         (list (macher-agent-vfs-make-entry 
-                vfs-file 
-                "original content on disk" 
-                "---\nname: virtual-skill\ndescription: A virtual test skill\n---\nThis body is completely virtual.")))
-        (let ((parsed (macher-agent-parse-skill-file vfs-file ctx)))
-          (expect (plist-get parsed :name) :to-equal "virtual-skill")
-          (expect (plist-get parsed :body) :to-equal "This body is completely virtual."))))
+                    (it "prioritises virtual edits inside the VFS when parsing SKILL.md"
+                        (let* ((ctx (macher-agent-resolve-context))
+                               (vfs-file "tests/fixtures/skills/global/SKILL.md"))
+                          (macher-agent--set-context-contents 
+                           ctx 
+                           (list (macher-agent-vfs-make-entry 
+                                  vfs-file 
+                                  "original content on disk" 
+                                  "---\nname: virtual-skill\ndescription: A virtual test skill\n---\nThis body is completely virtual.")))
+                          (let ((parsed (macher-agent-parse-skill-file vfs-file ctx)))
+                            (expect (plist-get parsed :name) :to-equal "virtual-skill")
+                            (expect (plist-get parsed :body) :to-equal "This body is completely virtual."))))
 
-    (it "resolves global skill tools by loading their script if not registered"
-      (let* ((loaded-tool-object (gptel-make-tool :name "mock-tool-load" :category "test")))
-        (setq mock-tool-load-global loaded-tool-object)
-        (spy-on 'file-exists-p :and-return-value t)
-        (spy-on 'insert-file-contents :and-call-fake (lambda (f) (insert "(setq mock-tool-load mock-tool-load-global)")))
-        (let ((resolved (macher-agent-resolve-tool "mock-tool-load" nil "tests/fixtures/skills/global/")))
-          (expect resolved :to-equal loaded-tool-object))))
+                    (it "resolves global skill tools by loading their script if not registered"
+                        (let* ((loaded-tool-object (gptel-make-tool :name "mock-tool-load" :category "test")))
+                          (setq mock-tool-load-global loaded-tool-object)
+                          (spy-on 'file-exists-p :and-return-value t)
+                          (spy-on 'insert-file-contents :and-call-fake (lambda (f) (insert "(setq mock-tool-load mock-tool-load-global)")))
+                          (let ((resolved (macher-agent-resolve-tool "mock-tool-load" nil "tests/fixtures/skills/global/")))
+                            (expect resolved :to-equal loaded-tool-object))))
 
-    (it "refuses to load workspace skill tools (security context)"
-      (let* ((mock-script-dir (expand-file-name "tests/fixtures/skills/workspace/scripts"))
-             (mock-script-path (expand-file-name "workspace-tool-1.el" mock-script-dir)))
-        ;; Setup mock script
-        (make-directory mock-script-dir t)
-        (with-temp-file mock-script-path
-          (insert "(setq workspace-tool-1 'workspace-loaded)"))
-        
-        ;; Test workspace parsing logic
-        (let ((ctx (macher-agent-resolve-context)))
-          (macher-agent--load-skill-from-path "tests/fixtures/skills/workspace/" ctx)
-          (let* ((workspace (macher-agent--get-context-workspace ctx))
-                 (skill-meta (alist-get 'workspace-skill (macher-agent-workspace-skills-alist workspace))))
-            (expect (plist-get skill-meta :context-dir) :to-be nil)))
-        
-        ;; Resolution should fail to load because context-dir is nil,
-        ;; returning the raw string fallback instead of a loaded tool object.
-        (let ((resolved (macher-agent-resolve-tool "workspace-tool-1" nil nil)))
-          (expect resolved :to-equal "workspace-tool-1"))
-        
-        (delete-directory mock-script-dir t)))
+                    (it "refuses to load workspace skill tools (security context)"
+                        (let* ((mock-script-dir (expand-file-name "tests/fixtures/skills/workspace/scripts"))
+                               (mock-script-path (expand-file-name "workspace-tool-1.el" mock-script-dir)))
+                          ;; Setup mock script
+                          (make-directory mock-script-dir t)
+                          (with-temp-file mock-script-path
+                            (insert "(setq workspace-tool-1 'workspace-loaded)"))
+                          
+                          ;; Test workspace parsing logic
+                          (let ((ctx (macher-agent-resolve-context)))
+                            (macher-agent--load-skill-from-path "tests/fixtures/skills/workspace/" ctx)
+                            (let* ((workspace (macher-agent--get-context-workspace ctx))
+                                   (skill-meta (alist-get 'workspace-skill (macher-agent-workspace-skills-alist workspace))))
+                              (expect (plist-get skill-meta :context-dir) :to-be nil)))
+                          
+                          ;; Resolution should fail to load because context-dir is nil,
+                          ;; returning the raw string fallback instead of a loaded tool object.
+                          (let ((resolved (macher-agent-resolve-tool "workspace-tool-1" nil nil)))
+                            (expect resolved :to-equal "workspace-tool-1"))
+                          
+                          (delete-directory mock-script-dir t)))
 
-    (it "verifies tool resolution hierarchy (workspace shadows package tools)"
-      (let* ((pkg-dir (make-temp-file "macher-pkg" t))
-             (ws-dir (make-temp-file "macher-ws" t))
-             (pkg-scripts (expand-file-name "scripts" pkg-dir))
-             (ws-scripts (expand-file-name "scripts" ws-dir))
-             (ws-a (gptel-make-tool :name "tool-a" :category "test1"))
-             (pkg-b (gptel-make-tool :name "tool-b" :category "test2")))
-        (setq mock-ws-a-global ws-a)
-        (setq mock-pkg-b-global pkg-b)
-        (make-directory pkg-scripts t)
-        (make-directory ws-scripts t)
-        ;; Package provides tool-a and tool-b
-        (with-temp-file (expand-file-name "tool-a.el" pkg-scripts) (insert "(setq tool-a 'pkg-a)"))
-        (with-temp-file (expand-file-name "tool-b.el" pkg-scripts) (insert "(setq tool-b mock-pkg-b-global)"))
-        ;; Workspace overrides tool-a
-        (with-temp-file (expand-file-name "tool-a.el" ws-scripts) (insert "(setq tool-a mock-ws-a-global)"))
-        
-        ;; Clear registry
-        (let* ((ctx (macher-agent-resolve-context))
-               (ws (macher-agent--get-context-workspace ctx)))
-          (clrhash (macher-agent-workspace-tools-registry ws)))
-        
-        ;; Resolve pkg first, then workspace shadows
-        (let* ((res-pkg-b (macher-agent-resolve-tool "tool-b" nil pkg-dir))
-               (res-ws-a (macher-agent-resolve-tool "tool-a" nil ws-dir)))
-          (expect res-pkg-b :to-equal pkg-b)
-          (expect res-ws-a :to-equal ws-a))
-        
-        (delete-directory pkg-dir t)
-        (delete-directory ws-dir t)))
-    
-    (it "applies skill tools correctly into gptel-tools when selected"
-      (let* ((gptel-tools nil)
-             (gptel--known-presets nil)
-             (gptel-directives nil)
-             (mock-tool-obj (if (fboundp 'gptel-make-tool)
-                                (gptel-make-tool :name "the_tool" :function (lambda () nil) :description "A tool")
-                              'the-tool)))
-        (spy-on 'gptel-tool-p :and-return-value t)
-        (let* ((ctx (macher-agent-resolve-context))
-               (workspace (macher-agent--get-context-workspace ctx)))
-          (puthash "selected-tool" mock-tool-obj (macher-agent-workspace-tools-registry workspace))
-          (setf (alist-get 'test-preset (macher-agent-workspace-skills-alist workspace))
-                (list :description "test" :system "test system" :tools (list mock-tool-obj) :context-dir nil))
-          
-          (with-temp-buffer
-            (let ((gptel--known-presets nil))
-              (macher-agent-initialize-skills ctx)
-              (let ((preset-def (buffer-local-value 'gptel--known-presets (current-buffer))))
-                (setq preset-def (alist-get 'test-preset preset-def))
-                (expect preset-def :not :to-be nil)
-                (expect (plist-get preset-def :tools) :to-equal '(:append ("the_tool")))))))))
+                    (it "verifies tool resolution hierarchy (workspace shadows package tools)"
+                        (let* ((pkg-dir (make-temp-file "macher-pkg" t))
+                               (ws-dir (make-temp-file "macher-ws" t))
+                               (pkg-scripts (expand-file-name "scripts" pkg-dir))
+                               (ws-scripts (expand-file-name "scripts" ws-dir))
+                               (ws-a (gptel-make-tool :name "tool-a" :category "test1"))
+                               (pkg-b (gptel-make-tool :name "tool-b" :category "test2")))
+                          (setq mock-ws-a-global ws-a)
+                          (setq mock-pkg-b-global pkg-b)
+                          (make-directory pkg-scripts t)
+                          (make-directory ws-scripts t)
+                          ;; Package provides tool-a and tool-b
+                          (with-temp-file (expand-file-name "tool-a.el" pkg-scripts) (insert "(setq tool-a 'pkg-a)"))
+                          (with-temp-file (expand-file-name "tool-b.el" pkg-scripts) (insert "(setq tool-b mock-pkg-b-global)"))
+                          ;; Workspace overrides tool-a
+                          (with-temp-file (expand-file-name "tool-a.el" ws-scripts) (insert "(setq tool-a mock-ws-a-global)"))
+                          
+                          ;; Clear registry
+                          (let* ((ctx (macher-agent-resolve-context))
+                                 (ws (macher-agent--get-context-workspace ctx)))
+                            (clrhash (macher-agent-workspace-tools-registry ws)))
+                          
+                          ;; Resolve pkg first, then workspace shadows
+                          (let* ((res-pkg-b (macher-agent-resolve-tool "tool-b" nil pkg-dir))
+                                 (res-ws-a (macher-agent-resolve-tool "tool-a" nil ws-dir)))
+                            (expect res-pkg-b :to-equal pkg-b)
+                            (expect res-ws-a :to-equal ws-a))
+                          
+                          (delete-directory pkg-dir t)
+                          (delete-directory ws-dir t)))
+                    
+                    (it "applies skill tools correctly into gptel-tools when selected"
+                        (let* ((gptel-tools nil)
+                               (gptel--known-presets nil)
+                               (gptel-directives nil)
+                               (mock-tool-obj (if (fboundp 'gptel-make-tool)
+                                                  (gptel-make-tool :name "the_tool" :function (lambda () nil) :description "A tool")
+                                                'the-tool)))
+                          (spy-on 'gptel-tool-p :and-return-value t)
+                          (let* ((ctx (macher-agent-resolve-context))
+                                 (workspace (macher-agent--get-context-workspace ctx)))
+                            (puthash "selected-tool" mock-tool-obj (macher-agent-workspace-tools-registry workspace))
+                            (setf (alist-get 'test-preset (macher-agent-workspace-skills-alist workspace))
+                                  (list :description "test" :system "test system" :tools (list mock-tool-obj) :context-dir nil))
+                            
+                            (with-temp-buffer
+                              (let ((gptel--known-presets nil))
+                                (macher-agent-initialize-skills ctx)
+                                (let ((preset-def (buffer-local-value 'gptel--known-presets (current-buffer))))
+                                  (setq preset-def (alist-get 'test-preset preset-def))
+                                  (expect preset-def :not :to-be nil)
+                                  (expect (plist-get preset-def :tools) :to-equal '(:append ("the_tool")))))))))
 
-    (it "merges and applies buffer-local macher-agent-presets during composed skill evaluation"
-      (let* ((gptel-tools nil)
-             (gptel--known-presets nil)
-             (gptel-directives nil)
-             (mock-tool-obj (if (fboundp 'gptel-make-tool)
-                                (gptel-make-tool :name "the_tool" :function (lambda () nil) :description "A tool")
-                              'the-tool)))
-        (spy-on 'gptel-tool-p :and-return-value t)
-        (let* ((ctx (macher-agent-resolve-context))
-               (workspace (macher-agent--get-context-workspace ctx)))
-          (puthash "selected-tool" mock-tool-obj (macher-agent-workspace-tools-registry workspace))
-          (setf (alist-get 'test-preset (macher-agent-workspace-skills-alist workspace))
-                (list :description "test" :system "test system" :tools (list mock-tool-obj) :context-dir nil))
-          
-          (with-temp-buffer
-            (let ((gptel--known-presets nil))
-              (macher-agent-initialize-skills ctx)
-              (setq-local macher-agent-presets '(test-preset))
-              (setq-local gptel-tools nil)
-              (let ((payload (macher-agent-compose-payload 
-                              (list :model nil :system nil :temperature nil :max-tokens nil :tools nil :known-presets gptel--known-presets)
-                              '(test-preset))))
-                (macher-agent--apply-payload-locally payload))
-              (expect gptel-tools :not :to-be nil)
-              (expect (car gptel-tools) :to-equal mock-tool-obj))))))
+                    (it "merges and applies buffer-local macher-agent-presets during composed skill evaluation"
+                        (let* ((gptel-tools nil)
+                               (gptel--known-presets nil)
+                               (gptel-directives nil)
+                               (mock-tool-obj (if (fboundp 'gptel-make-tool)
+                                                  (gptel-make-tool :name "the_tool" :function (lambda () nil) :description "A tool")
+                                                'the-tool)))
+                          (spy-on 'gptel-tool-p :and-return-value t)
+                          (let* ((ctx (macher-agent-resolve-context))
+                                 (workspace (macher-agent--get-context-workspace ctx)))
+                            (puthash "selected-tool" mock-tool-obj (macher-agent-workspace-tools-registry workspace))
+                            (setf (alist-get 'test-preset (macher-agent-workspace-skills-alist workspace))
+                                  (list :description "test" :system "test system" :tools (list mock-tool-obj) :context-dir nil))
+                            
+                            (with-temp-buffer
+                              (let ((gptel--known-presets nil))
+                                (macher-agent-initialize-skills ctx)
+                                (setq-local macher-agent-presets '(test-preset))
+                                (setq-local gptel-tools nil)
+                                (let ((payload (macher-agent-compose-payload 
+                                                (list :model nil :system nil :temperature nil :max-tokens nil :tools nil :known-presets gptel--known-presets)
+                                                '(test-preset))))
+                                  (macher-agent--apply-payload-locally payload))
+                                (expect gptel-tools :not :to-be nil)
+                                (expect (car gptel-tools) :to-equal mock-tool-obj))))))
 
-    (it "expands org-macros in SKILL.md body"
-      (let* ((parsed (macher-agent-parse-skill-file "tests/fixtures/skills/macro-skill/SKILL.md")))
-        (expect (plist-get parsed :body) :to-match "Version: 0.1.0")))
+                    (it "expands org-macros in SKILL.md body"
+                        (let* ((parsed (macher-agent-parse-skill-file "tests/fixtures/skills/macro-skill/SKILL.md")))
+                          (expect (plist-get parsed :body) :to-match "Version: 0.1.0")))
 
-    (it "creates a preset when allowed-tools is provided"
-      (let* ((mock-dir (make-temp-file "macher-test-skills-preset" t))
-             (skill-dir (expand-file-name "test-skill" mock-dir)))
-        (make-directory skill-dir t)
-        (with-temp-file (expand-file-name "SKILL.md" skill-dir)
-          (insert "---\nname: my-preset\ndescription: test\nallowed-tools:\n  - some-tool\nmodel: gpt-4o\n---\nPreset body"))
-        (spy-on 'macher-agent-resolve-tool :and-return-value "some-tool")
-        (with-temp-buffer
-          (let ((gptel-directives nil)
-                (gptel--known-presets nil))
-            (macher-agent-initialize-skills nil mock-dir)
-            
-            (let ((preset-def (alist-get 'my-preset gptel--known-presets)))
-              (expect preset-def :not :to-be nil)
-              (expect (plist-get preset-def :system) :to-equal "Preset body")
-              (expect (plist-get preset-def :model) :to-equal 'gpt-4o)
-              (expect (plist-get preset-def :tools) :to-equal '(:append ("some-tool"))))
-            (delete-directory mock-dir t)))))
+                    (it "creates a preset when allowed-tools is provided"
+                        (let* ((mock-dir (make-temp-file "macher-test-skills-preset" t))
+                               (skill-dir (expand-file-name "test-skill" mock-dir)))
+                          (make-directory skill-dir t)
+                          (with-temp-file (expand-file-name "SKILL.md" skill-dir)
+                            (insert "---\nname: my-preset\ndescription: test\nallowed-tools:\n  - some-tool\nmodel: gpt-4o\n---\nPreset body"))
+                          (spy-on 'macher-agent-resolve-tool :and-return-value "some-tool")
+                          (with-temp-buffer
+                            (let ((gptel-directives nil)
+                                  (gptel--known-presets nil))
+                              (macher-agent-initialize-skills nil mock-dir)
+                              
+                              (let ((preset-def (alist-get 'my-preset gptel--known-presets)))
+                                (expect preset-def :not :to-be nil)
+                                (expect (plist-get preset-def :system) :to-equal "Preset body")
+                                (expect (plist-get preset-def :model) :to-equal 'gpt-4o)
+                                (expect (plist-get preset-def :tools) :to-equal '(:append ("some-tool"))))
+                              (delete-directory mock-dir t)))))
 
-    (it "injects directly into gptel-directives when allowed-tools is omitted"
-      (let* ((mock-dir (make-temp-file "macher-test-skills-directive" t))
-             (skill-dir (expand-file-name "test-skill" mock-dir)))
-        (make-directory skill-dir t)
-        (with-temp-file (expand-file-name "SKILL.md" skill-dir)
-          (insert "---\nname: my-directive\n---\nDirective body"))
-        (with-temp-buffer
-          (let ((gptel-directives nil)
-                (gptel--known-presets nil))
-            (macher-agent-initialize-skills nil mock-dir)
-            (expect (alist-get 'my-directive gptel-directives) :to-equal "Directive body")
-            (let ((preset-def (alist-get 'my-directive gptel--known-presets)))
-              (expect preset-def :not :to-be nil)
-              (expect (plist-get preset-def :system) :to-equal "Directive body"))
-            (delete-directory mock-dir t)))))))
+                    (it "injects directly into gptel-directives when allowed-tools is omitted"
+                        (let* ((mock-dir (make-temp-file "macher-test-skills-directive" t))
+                               (skill-dir (expand-file-name "test-skill" mock-dir)))
+                          (make-directory skill-dir t)
+                          (with-temp-file (expand-file-name "SKILL.md" skill-dir)
+                            (insert "---\nname: my-directive\n---\nDirective body"))
+                          (with-temp-buffer
+                            (let ((gptel-directives nil)
+                                  (gptel--known-presets nil))
+                              (macher-agent-initialize-skills nil mock-dir)
+                              (expect (alist-get 'my-directive gptel-directives) :to-equal "Directive body")
+                              (let ((preset-def (alist-get 'my-directive gptel--known-presets)))
+                                (expect preset-def :not :to-be nil)
+                                (expect (plist-get preset-def :system) :to-equal "Directive body"))
+                              (delete-directory mock-dir t)))))))
 
 (provide 'macher-agent-skills-test)

--- a/tests/macher-agent-test.el
+++ b/tests/macher-agent-test.el
@@ -78,39 +78,39 @@
                                   (let* ((test-dir (make-temp-file "macher-test-dir" t))
                                          (test-file (expand-file-name "test.txt" test-dir))
                                          (ctx (macher--make-context :dirty-p t)))
-                                    
-                                    (setf (macher-context-contents ctx) 
+
+                                    (setf (macher-context-contents ctx)
                                           (list (macher-agent-vfs-make-entry test-file "v1" "v2-local")))
-                                    
+
                                     (with-temp-file test-file (insert "v2-remote"))
-                                    
+
                                     (macher-agent--auto-sync-context ctx)
-                                    
+
                                     (let ((entry (cl-find test-file (macher-context-contents ctx) :key #'macher-agent-vfs-entry-path :test #'equal)))
                                       (expect (macher-agent-vfs-entry-orig entry) :to-equal "v2-remote")
                                       (expect (macher-agent-vfs-entry-curr entry) :to-equal "v2-remote"))
-                                    
+
                                     (delete-directory test-dir t)))
 
                               (it "preserves unapplied virtual edits across tool calls if the physical state has not mutated"
                                   (let* ((entry (macher-agent-vfs-make-entry "test-file.el" "original state" "proposed ghost state")))
-                                    
+
                                     ;; Mock the disk returning the exact same original state
                                     (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "original state")
-                                    
+
                                     (macher-agent--sync-context-entry entry)
-                                    
+
                                     ;; The agent's unapplied virtual edit MUST survive!
                                     (expect (macher-agent-vfs-entry-curr entry) :to-equal "proposed ghost state")))
 
                               (it "invalidates edits and prevents ghost diffs if the underlying buffer or file is destroyed"
                                   (let* ((entry (macher-agent-vfs-make-entry "test-file.el" "original state" "proposed ghost state")))
-                                    
+
                                     ;; Mock the buffer being killed or file being deleted (returns nil)
                                     (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value nil)
-                                    
+
                                     (macher-agent--sync-context-entry entry)
-                                    
+
                                     ;; The concurrency control detects the change and wipes the ghost edits
                                     (expect (macher-agent-vfs-entry-orig entry) :to-be nil)
                                     (expect (macher-agent-vfs-entry-curr entry) :to-be nil)))
@@ -121,26 +121,26 @@
                                          (pure-name "*macher-dummy-buf*")
                                          (file-buf (find-file-noselect file-path))
                                          (pure-buf (get-buffer-create pure-name)))
-                                    
+
                                     ;; 1. Add one physical file and one pure buffer to the context
                                     (push (macher-agent-vfs-make-entry file-path "a" "b") (macher-context-contents ctx))
                                     (push (macher-agent-vfs-make-entry pure-name "x" "y") (macher-context-contents ctx))
                                     (expect (length (macher-context-contents ctx)) :to-equal 2)
-                                    
+
                                     ;; 2. Run the splitter
                                     (let* ((split (macher-agent--split-context ctx))
                                            (file-ctx (car split))
                                            (buf-ctx (cdr split)))
-                                      
+
                                       ;; 3. Verify physical files went to the left (car)
                                       (expect (length (macher-context-contents file-ctx)) :to-equal 1)
                                       (expect (cl-find file-path (macher-context-contents file-ctx) :key #'macher-agent-vfs-entry-path :test #'equal) :to-be-truthy)
                                       (expect (cl-find pure-name (macher-context-contents file-ctx) :key #'macher-agent-vfs-entry-path :test #'equal) :to-be nil)
-                                      
+
                                       ;; 4. Verify pure buffers went to the right (cdr)
                                       (expect (cl-find pure-name (macher-context-contents buf-ctx) :key #'macher-agent-vfs-entry-path :test #'equal) :to-be-truthy)
                                       (expect (cl-find file-path (macher-context-contents buf-ctx) :key #'macher-agent-vfs-entry-path :test #'equal) :to-be nil))
-                                    
+
                                     (kill-buffer file-buf)
                                     (kill-buffer pure-buf)))
 
@@ -149,12 +149,12 @@
                                          (ctx (macher--make-context :dirty-p t))
                                          (file-path (expand-file-name "test.txt")))
                                     (push (macher-agent-vfs-make-entry file-path "old" "new") (macher-context-contents ctx))
-                                    
+
                                     (with-current-buffer buf
                                       (setq-local macher-agent--is-workspace t)
                                       (setq-local macher-agent--persistent-context ctx)
                                       (setq-local macher-agent--active-fsm nil))
-                                    
+
                                     (with-current-buffer buf
                                       (macher-agent-apply-virtual-buffers))
                                     (kill-buffer buf))))
@@ -167,15 +167,15 @@
                                          ;; Register a skill with a specific model
                                          (skill-data '(:description "Test" :model gpt-4o :has-tools nil :context-dir nil :system "test"))
                                          (execution (macher--make-action-execution :action skill-name)))
-                                    
+
                                     (let ((workspace (macher-agent--get-context-workspace (macher-agent-resolve-context))))
                                       (setf (alist-get skill-name (macher-agent-workspace-skills-alist workspace)) skill-data))
-                                    
+
                                     ;; Execute the initialisation
                                     (with-temp-buffer
                                       (let ((gptel--known-presets nil))
                                         (macher-agent-initialize-skills (macher-agent-resolve-context))
-                                        
+
                                         (let ((preset-def (alist-get skill-name gptel--known-presets)))
                                           (expect preset-def :not :to-be nil)
                                           (expect (plist-get preset-def :model) :to-equal 'gpt-4o))))))
@@ -188,28 +188,28 @@
                                          (skill-data '(:description "Test" :model nil :has-tools nil :context-dir nil :system "test"))
                                          (execution (macher--make-action-execution :action skill-name))
                                          (original-model gptel-model))
-                                    
+
                                     (let ((workspace (macher-agent--get-context-workspace (macher-agent-resolve-context))))
                                       (setf (alist-get skill-name (macher-agent-workspace-skills-alist workspace)) skill-data))
-                                    
+
                                     (with-temp-buffer
                                       (let ((gptel--known-presets nil))
                                         (macher-agent-initialize-skills (macher-agent-resolve-context))
-                                        
+
                                         (let ((preset-def (alist-get skill-name gptel--known-presets)))
                                           (expect preset-def :not :to-be nil)
                                           ;; plist-member returns the tail if found, nil if not. Since model is not present, it should not exist in the plist.
                                           (expect (plist-member preset-def :model) :to-be nil)))))))
                     (describe "Virtual File System (VFS) Concurrency Control"
-                              
+
                               (describe "macher-agent--sync-context-entry"
-                                        
+
                                         (it "preserves unapplied virtual edits if the physical disk has NOT mutated"
                                             (let* ((entry (macher-agent-vfs-make-entry "test.el" "original state" "agent edit")))
-                                              
+
                                               ;; Mock the disk returning the exact same original state
                                               (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "original state")
-                                              
+
                                               (let ((mutated (macher-agent--sync-context-entry entry)))
                                                 (expect mutated :to-be nil)
                                                 (expect (macher-agent-vfs-entry-orig entry) :to-equal "original state")
@@ -217,10 +217,10 @@
 
                                         (it "fast-forwards a clean virtual memory if the physical disk mutates naturally"
                                             (let* ((entry (macher-agent-vfs-make-entry "test.el" "original state" "original state")))
-                                              
+
                                               ;; Mock a physical edit happening while the agent had NO pending edits
                                               (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "new physical state")
-                                              
+
                                               (let ((mutated (macher-agent--sync-context-entry entry)))
                                                 (expect mutated :to-be t)
                                                 (expect (macher-agent-vfs-entry-orig entry) :to-equal "new physical state")
@@ -228,10 +228,10 @@
 
                                         (it "OPTIMISTIC CONCURRENCY: invalidates virtual edits if a hostile physical mutation occurs"
                                             (let* ((entry (macher-agent-vfs-make-entry "test.el" "original state" "agent edit")))
-                                              
+
                                               ;; Mock the user manually editing the file while the agent was thinking
                                               (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "user physical edit")
-                                              
+
                                               (let ((mutated (macher-agent--sync-context-entry entry)))
                                                 ;; The system MUST detect the conflict and aggressively drop the agent's delta
                                                 (expect mutated :to-be t)
@@ -240,11 +240,11 @@
 
                                         (it "fast-forwards virtual memory if the physical mutation perfectly matches the virtual delta (patch applied)"
                                             (let* ((entry (macher-agent-vfs-make-entry "test.el" "original state" "agent edit")))
-                                              
+
                                               ;; Mock the state immediately after the user applies the patch.
                                               ;; The disk now matches the agent's unapplied edit perfectly.
                                               (spy-on 'macher-agent--read-content-from-disk-or-buffer :and-return-value "agent edit")
-                                              
+
                                               (let ((mutated (macher-agent--sync-context-entry entry)))
                                                 ;; The system MUST recognise the patch was applied and fast-forward the baseline.
                                                 ;; It returns t (mutated) and updates orig to match new, preventing duplicate patches.
@@ -254,42 +254,42 @@
 
                               )
                     (describe "Macher-Agent Tool Registry Resilience"
-                              
+
                               (it "ensures custom tools survive the preset purge and retain correct category"
                                   (let* (;; 1. Define a tool mimicking your agent tools
-                                         (custom-tool (gptel-make-tool 
-                                                       :name "cargo_check_tool" 
-                                                       :function #'ignore 
-                                                       :category "macher-agent-rust" 
-                                                       :description "Test tool" 
+                                         (custom-tool (gptel-make-tool
+                                                       :name "cargo_check_tool"
+                                                       :function #'ignore
+                                                       :category "macher-agent-rust"
+                                                       :description "Test tool"
                                                        :args nil))
                                          ;; 2. Simulate the clearing function used by presets like macher-ro
                                          (clear-fn (plist-get (plist-get macher--preset-clear-tools :tools) :function))
                                          ;; 3. Simulate a scenario where a preset attempts to purge everything but 'macher' category tools
-                                         (tools-list (list custom-tool 
+                                         (tools-list (list custom-tool
                                                            (gptel-make-tool :name "native_tool" :function #'ignore :category "macher" :description "native" :args nil)))
                                          (filtered-tools (funcall clear-fn tools-list)))
-                                    
+
                                     ;; PROOF: The custom tool MUST survive because it does not match the 'macher' category purge
                                     (expect (seq-find (lambda (tool) (string= (gptel-tool-name tool) "cargo_check_tool")) filtered-tools) :not :to-be nil)
                                     (expect (gptel-tool-category custom-tool) :to-equal "macher-agent-rust")))
 
                               (it "verifies that tools identified as 'macher' category get context injected"
                                   (let* ((mock-fsm (gptel-make-fsm))
-                                         (mock-tool (gptel-make-tool :name "test_tool" 
-                                                                     :function (lambda (ctx) ctx) 
-                                                                     :category "macher" 
+                                         (mock-tool (gptel-make-tool :name "test_tool"
+                                                                     :function (lambda (ctx) ctx)
+                                                                     :category "macher"
                                                                      :description "test" :args nil))
                                          (mock-context 'injected-context))
-                                    
+
                                     (setf (gptel-fsm-info mock-fsm) (list :tools (list mock-tool) :buffer (current-buffer)))
-                                    
+
                                     ;; Run the macher setup logic
                                     (macher--setup-tools mock-fsm (lambda () mock-context))
-                                    
+
                                     (let* ((processed-tools (plist-get (gptel-fsm-info mock-fsm) :tools))
                                            (processed-tool (car processed-tools)))
-                                      
+
                                       ;; PROOF: The tool has been wrapped and is now expecting the context
                                       (expect (funcall (gptel-tool-function processed-tool)) :to-equal 'injected-context))))
 
@@ -301,33 +301,33 @@
                                          (macher-agent--allow-gptel-restore t)
                                          (orig-called nil)
                                          (orig-fun (lambda (&rest _args) (setq orig-called t))))
-                                    
+
                                     (unwind-protect
                                         (progn
                                           ;; 1. Set up the other buffer to simulate an active workspace that could be leaked
                                           (with-current-buffer other-buf
                                             (setq-local default-directory other-dir)
                                             (macher-agent--init-workspace-state other-dir))
-                                          
+
                                           ;; 2. Set up the restored buffer with its correct default-directory
                                           (with-current-buffer restore-buf
                                             (setq-local default-directory restore-dir)
-                                            
+
                                             ;; Verify that prior to restore advice, persistent-context is nil
                                             (expect (bound-and-true-p macher-agent--persistent-context) :to-be nil)
-                                            
+
                                             ;; Execute the restore advice
                                             (macher-agent--gptel-restore-advice orig-fun)
-                                            
+
                                             ;; Verify the original restore function was called
                                             (expect orig-called :to-be t)
-                                            
+
                                             ;; Verify that the correct workspace context was created and bound
                                             (let ((local-ctx (bound-and-true-p macher-agent--persistent-context)))
                                               (expect local-ctx :not :to-be nil)
                                               (let ((workspace (macher-agent--get-context-workspace local-ctx)))
-                                                (expect (macher-agent-root workspace) :to-equal (expand-file-name restore-dir))))))
-                                      
+                                                (expect (macher-agent-workspace-project-root workspace) :to-equal (expand-file-name restore-dir))))))
+
                                       ;; Clean up temp buffers
                                       (when (buffer-live-p other-buf) (kill-buffer other-buf))
                                       (when (buffer-live-p restore-buf) (kill-buffer restore-buf))))))
@@ -338,22 +338,21 @@
                                                    (ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "test.png" "" "img-data"))))
                                                    (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
                                               (spy-on 'macher-agent-resolve-context :and-return-value ctx)
-                                              (let ((result (funcall tool-fn "test.png")))
+                                              (let ((result (funcall tool-fn nil "test.png")))
                                                 (expect result :to-match "gptel media send option is off"))))
                                         (it "permits access to valid media files inside the workspace without triggering VFS text security locks"
                                             (let* ((gptel-track-media t)
-                                                   (session (make-macher-agent-session :id "test"))
-                                                   (macher-agent--active-fsm 'mock-fsm)
-                                                   (mock-info (list :macher-agent-session session))
                                                    (ctx (macher--make-context :contents nil))
+                                                   (macher-agent--active-fsm (gptel-make-fsm))
+                                                   (mock-info (list :macher-agent-context ctx))
                                                    (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
-                                              (spy-on 'gptel-fsm-info :and-return-value mock-info)
+                                              (setf (gptel-fsm-info macher-agent--active-fsm) mock-info)
                                               (spy-on 'macher-agent-resolve-context :and-return-value ctx)
                                               (spy-on 'macher-agent-context-classify-entry :and-return-value 'media)
                                               (spy-on 'file-exists-p :and-return-value t)
                                               (spy-on 'mailcap-file-name-to-mime-type :and-return-value "image/png")
                                               (spy-on 'insert-file-contents-literally :and-call-fake (lambda (&rest _args) (insert "mock-image-data")))
-                                              (let ((result (funcall tool-fn "test_workspace_image.png")))
+                                              (let ((result (funcall tool-fn nil "test_workspace_image.png")))
                                                 (expect result :to-match "SUCCESS: Media 'test_workspace_image.png'"))))
                                         (it "throws an error if the tool cannot determine MIME type"
                                             (let* ((gptel-track-media t)
@@ -362,86 +361,85 @@
                                               (spy-on 'macher-agent-resolve-context :and-return-value ctx)
                                               (spy-on 'file-exists-p :and-return-value t)
                                               (spy-on 'mailcap-file-name-to-mime-type :and-return-value nil)
-                                              (let ((result (funcall tool-fn "unauthorized_script.sh")))
+                                              (let ((result (funcall tool-fn nil "unauthorized_script.sh")))
                                                 (expect result :to-match "Could not determine MIME type"))))
                                         (it "stages media in the session pending-media instead of polluting gptel-context"
                                             (let* ((gptel-track-media t)
                                                    (gptel-context nil)
-                                                   (session (make-macher-agent-session :id "test"))
-                                                   (macher-agent--active-fsm 'mock-fsm)
-                                                   (mock-info (list :macher-agent-session session))
                                                    (ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry "test.png" "" "img-data"))))
+                                                   (macher-agent--active-fsm (gptel-make-fsm))
+                                                   (mock-info (list :macher-agent-context ctx))
                                                    (tool-fn (gptel-tool-function macher-agent-read-media-in-workspace-tool)))
-                                              (spy-on 'gptel-fsm-info :and-return-value mock-info)
+                                              (setf (gptel-fsm-info macher-agent--active-fsm) mock-info)
                                               (spy-on 'macher-agent-resolve-context :and-return-value ctx)
                                               (spy-on 'mailcap-file-name-to-mime-type :and-return-value "image/png")
                                               (spy-on 'file-exists-p :and-return-value t)
-                                              (let ((result (funcall tool-fn "test.png")))
+                                              (let ((result (funcall tool-fn nil "test.png")))
                                                 (expect result :to-match "SUCCESS: Media")
                                                 (expect gptel-context :to-be nil)
-                                                (expect (car (car (macher-agent-session-pending-media session))) :to-equal "aW1nLWRhdGE="))))
+                                                (expect (car (car (macher-agent--get-context-data ctx :pending-media))) :to-equal "aW1nLWRhdGE="))))
 
                                         (it "injects pending media into FSM payload and clears the queue pre-flight"
                                             (let* ((buf (current-buffer))
                                                    (mock-backend 'mock-backend)
                                                    (mock-data '((:role "system" :content "sys")))
-                                                   (session (make-macher-agent-session :id "test" :pending-media '(("mockbase64" :mime "image/png"))))
-                                                   (mock-info (list :buffer buf :backend mock-backend :data mock-data :macher-agent-session session))
-                                                   
+                                                   (ctx (macher--make-context :contents nil))
+                                                   (mock-info (list :buffer buf :backend mock-backend :data mock-data :macher-agent-context ctx))
+
                                                    ;; We can safely use a mock symbol again!
-                                                   (mock-fsm 'mock-fsm)
-                                                   
+                                                   (mock-fsm (gptel-make-fsm))
+
                                                    (orig-called nil)
                                                    (orig-fun (lambda (fsm &rest _) (setq orig-called fsm))))
-                                              
-                                              ;; Spy on the accessor to intercept the dynamic funcall
-                                              (spy-on 'gptel-fsm-info :and-return-value mock-info)
+
+                                              (macher-agent--set-context-data ctx :pending-media '(("mockbase64" :mime "image/png")))
+
+                                              (setf (gptel-fsm-info mock-fsm) mock-info)
                                               (spy-on 'gptel--inject-media)
                                               (spy-on 'gptel--inject-prompt)
-                                              
+
                                               ;; Execute the restored advice
                                               (macher-agent--inject-media-fsm-advice orig-fun mock-fsm)
-                                              
+
                                               ;; Verify injection lifecycle
-                                              (expect 'gptel-fsm-info :to-have-been-called-with mock-fsm)
                                               (expect 'gptel--inject-media :to-have-been-called)
                                               (expect 'gptel--inject-prompt :to-have-been-called)
                                               (expect orig-called :to-equal mock-fsm)
-                                              (expect (macher-agent-session-pending-media session) :to-be nil))))
+                                              (expect (macher-agent--get-context-data ctx :pending-media) :to-be nil))))
 
                               (describe "rsync command building"
-                                        
+
                                         (it "constructs a shell string using git ls-files"
                                             ;; Intercept call-process to return 0 (success).
                                             ;; This simulates a valid git repository and bypasses the physical directory check.
                                             (spy-on 'call-process :and-return-value 0)
-                                            
+
                                             (let* ((src "/my/project/")
                                                    (dest "/tmp/sandbox/")
                                                    (cmd (macher-agent--build-rsync-cmd src dest)))
-                                              
+
                                               (expect (stringp cmd) :to-be t)
-                                              (expect (string-match-p "git ls-files" cmd) :to-be-truthy)
-                                              (expect (string-match-p "rsync -aLC --delete --files-from=-" cmd) :to-be-truthy)
-                                              
+                                              (expect (string-match-p "git .*ls-files" cmd) :to-be-truthy)
+                                              (expect (string-match-p "rsync -aLC --delete --from0 --files-from=-" cmd) :to-be-truthy)
+
                                               ;; Optional but good practice: verify our mock was actually triggered
                                               (expect 'call-process :to-have-been-called-with
                                                       "git" nil nil nil "rev-parse" "--is-inside-work-tree")))))
 
                     (describe "Macher-Agent Tool Category Isolation"
-                              
+
                               (it "preserves the custom category to avoid being purged by upstream read-only presets"
-                                  (let ((mock-tool (gptel-make-tool :name "my_custom_tool" 
-                                                                    :function #'ignore 
-                                                                    :category "macher-agent-calendar" 
-                                                                    :description "test" 
+                                  (let ((mock-tool (gptel-make-tool :name "my_custom_tool"
+                                                                    :function #'ignore
+                                                                    :category "macher-agent-calendar"
+                                                                    :description "test"
                                                                     :args nil))
                                         ;; Extract the clearing function from the upstream preset definition
                                         (clear-fn (plist-get (plist-get macher--preset-clear-tools :tools) :function)))
-                                    
+
                                     ;; The custom tool MUST maintain its distinct category boundary
                                     (expect (gptel-tool-category mock-tool) :not :to-equal macher-tool-category)
-                                    
+
                                     ;; It MUST survive the upstream framework's aggressive tool purge
                                     (let ((filtered-tools (funcall clear-fn (list mock-tool))))
                                       (expect (length filtered-tools) :to-equal 1)
@@ -469,46 +467,46 @@
                                               (delete-directory sandbox-dir t))))
 
                               (describe "macher-agent--vfs-apply-overlay"
-                                        
+
                                         (it "reroutes virtual edits to the ephemeral sandbox, protecting the physical disk"
                                             (let* ((workspace-root "/my/project/")
                                                    (sandbox-dir "/tmp/sandbox-12345/")
                                                    ;; Create a mock context representing a dirty workspace
-                                                   (mock-ws (cons 'agent workspace-root))
-                                                   (mock-ctx (macher--make-context :dirty-p t 
+                                                   (mock-ws (make-macher-agent-workspace :project-root workspace-root))
+                                                   (mock-ctx (macher--make-context :dirty-p t
                                                                                    :workspace mock-ws
                                                                                    :contents (list (macher-agent-vfs-make-entry "/my/project/src/main.rs" "orig" "new content"))))
                                                    (write-region-called-with nil))
-                                              
+
                                               ;; Spy on file-in-directory-p to allow mock/non-existent sandbox directories
                                               (spy-on 'file-in-directory-p :and-return-value t)
 
                                               ;; Mock the context root provider (struct access)
                                               (spy-on 'macher--workspace-root :and-return-value workspace-root)
-                                              
+
                                               ;; Intercept the destructive write action
-                                              (spy-on 'write-region :and-call-fake 
+                                              (spy-on 'write-region :and-call-fake
                                                       (lambda (start _end filename &rest _)
                                                         (push (list start filename) write-region-called-with)))
-                                              
+
                                               (macher-agent--vfs-apply-overlay mock-ctx sandbox-dir)
-                                              
+
                                               ;; The orchestrator MUST execute a file write...
                                               (expect 'write-region :to-have-been-called)
-                                              
+
                                               ;; ...it MUST write the new virtual content...
                                               (expect (caar write-region-called-with) :to-equal "new content")
-                                              
+
                                               ;; ...and CRITICALLY, it MUST write it to the sandbox, NOT the physical /my/project/ path!
                                               (expect (cadar write-region-called-with) :to-equal "/tmp/sandbox-12345/src/main.rs")))
 
                                         (it "does not flush anything if the virtual memory is clean"
                                             (let* ((mock-ctx (macher--make-context :dirty-p nil :contents nil)))
-                                              
+
                                               (spy-on 'write-region)
-                                              
+
                                               (macher-agent--vfs-apply-overlay mock-ctx "/tmp/sandbox-12345/")
-                                              
+
                                               ;; Ensure no ghost files are created in the sandbox
                                               (expect 'write-region :not :to-have-been-called))))
 
@@ -518,34 +516,34 @@
                                               (spy-on 'macher-agent--vfs-verify-clean-merge :and-call-fake (lambda (&rest _) (push 'merge call-order)))
                                               (spy-on 'macher-agent--vfs-sync-baseline :and-call-fake (lambda (&rest _) (push 'sync call-order)))
                                               (spy-on 'macher-agent--vfs-apply-overlay :and-call-fake (lambda (&rest _) (push 'overlay call-order)))
-                                              
+
                                               ;; Execute a dummy tool
                                               (let ((mock-context (macher--make-context :workspace nil :contents nil)))
                                                 (spy-on 'macher-agent-context-root :and-return-value "/my/project/")
                                                 (spy-on 'make-temp-file :and-return-value "/tmp/sandbox-12345/")
                                                 (spy-on 'delete-directory)
                                                 (spy-on 'shell-command-to-string :and-return-value "running")
-                                                
+
                                                 (macher-agent-with-strict-vfs-pipeline mock-context
                                                                                        (shell-command-to-string "echo 'running'")))
-                                              
+
                                               ;; 1. Assert they were all called
                                               (expect 'macher-agent--vfs-verify-clean-merge :to-have-been-called)
                                               (expect 'macher-agent--vfs-sync-baseline :to-have-been-called)
                                               (expect 'macher-agent--vfs-apply-overlay :to-have-been-called)
-                                              
+
                                               ;; 2. Assert exact execution order
                                               (expect (reverse call-order) :to-equal '(merge sync overlay))))
-                                        
+
                                         (it "does not mangle OS-level absolute sandbox paths during rsync"
                                             ;; This specific test prevents the regression we just experienced
                                             (spy-on 'macher-agent--build-rsync-cmd :and-return-value "echo dummy")
                                             (spy-on 'delete-directory)
-                                            
+
                                             (let ((mock-context (macher--make-context :workspace nil :contents nil)))
                                               (spy-on 'macher-agent-context-root :and-return-value "/my/project/")
                                               (macher-agent-with-strict-vfs-pipeline mock-context nil))
-                                            
+
                                             ;; The destination argument to rsync MUST be an absolute path in /tmp or /var
                                             (let ((rsync-dest-arg (nth 1 (spy-calls-args-for 'macher-agent--build-rsync-cmd 0))))
                                               (expect (file-name-absolute-p rsync-dest-arg) :to-be t)))))
@@ -560,7 +558,8 @@
                                     (kill-buffer buf)))
                               (it "macher-agent-add-subagent creates a buffer and tracks it globally"
                                   (let* ((mock-workspace (make-macher-agent-workspace :project-root "/tmp/"))
-                                         (mock-context (macher-agent--make-vfs-context :workspace (cons 'agent mock-workspace) :contents nil)))
+                                         (mock-context (macher-agent--make-vfs-context :workspace mock-workspace :contents nil)))
+                                    (puthash (expand-file-name "/tmp/") mock-context macher-agent-active-workspaces)
                                     (spy-on 'macher-agent-resolve-context :and-return-value mock-context)
                                     (let ((buf (macher-agent-add-subagent "test-worker" "/tmp/" nil mock-context)))
                                       (expect (buffer-live-p buf) :to-be t)
@@ -571,12 +570,12 @@
                                   (let* ((buf (generate-new-buffer "live-target"))
                                          (ctx (macher--make-context :contents (list (macher-agent-vfs-make-entry (buffer-name buf) "old" "new text")))))
                                     (with-current-buffer buf (insert "old"))
-                                    
+
                                     (spy-on 'macher-agent-resolve-context :and-return-value ctx)
                                     (spy-on 'macher-agent--auto-sync-context)
-                                    
+
                                     (macher-agent-apply-virtual-buffers)
-                                    
+
                                     (with-current-buffer buf
                                       (expect (buffer-string) :to-equal "new text"))
                                     (kill-buffer buf)))
@@ -627,27 +626,26 @@
                                              "Mock async tool"
                                            :category "test"
                                            :args (list (list :name "arg1" :type 'string) (list :name "arg2" :type 'string))
-                                           :command-fn (lambda (payload)
+                                           :command-fn (lambda (payload _context _root)
                                                          (make-macher-agent-lisp-result-response :payload (format "Async %s %s" (plist-get payload :arg1) (plist-get payload :arg2)))))
 
                                          (macher-agent-make-tool mock-sync-contract-tool
                                              "Mock sync tool"
                                            :category "test"
                                            :args (list (list :name "arg1" :type 'string))
-                                           :command-fn (lambda (payload)
+                                           :command-fn (lambda (payload _context _root)
                                                          (make-macher-agent-lisp-result-response :payload (format "Sync %s" (plist-get payload :arg1))))))
 
                                         (it "generates variadic signatures for async tools to safely absorb FSM contexts"
                                             (let* ((tool-fn (gptel-tool-function mock-async-contract-tool))
                                                    (arity (func-arity tool-fn)))
-                                              ;; A variadic &rest signature always has a minimum of 0 and a maximum of 'many
-                                              (expect (car arity) :to-equal 0)
+                                              (expect (car arity) :to-equal 1)
                                               (expect (cdr arity) :to-equal 'many)))
 
                                         (it "generates variadic signatures for sync tools to safely absorb FSM contexts"
                                             (let* ((tool-fn (gptel-tool-function mock-sync-contract-tool))
                                                    (arity (func-arity tool-fn)))
-                                              (expect (car arity) :to-equal 0)
+                                              (expect (car arity) :to-equal 1)
                                               (expect (cdr arity) :to-equal 'many))))
 
                               (describe "Tool Lifecycle Hooks"
@@ -671,8 +669,8 @@
                                                           (setq pre-called (list name args))
                                                           nil))
                                               (funcall (gptel-tool-function mock-sync-contract-tool)
-                                                       "hello"
-                                                       (lambda (res) (setq callback-result res)))
+                                                       (lambda (res) (setq callback-result res))
+                                                       "hello")
                                               (expect pre-called :to-equal (list 'mock-sync-contract-tool '(:arg1 "hello")))
                                               (expect callback-result :to-match "Execution blocked by macher-agent-pre-tool-use-hook")))
 
@@ -682,15 +680,15 @@
                                                         (lambda (_name _args)
                                                           (error "Custom pre error")))
                                               (funcall (gptel-tool-function mock-sync-contract-tool)
-                                                       "hello"
-                                                       (lambda (res) (setq callback-result res)))
+                                                       (lambda (res) (setq callback-result res))
+                                                       "hello")
                                               (expect callback-result :to-match "Execution blocked by error in macher-agent-pre-tool-use-hook: Custom pre error")))
 
                                         (it "runs permission-request-hook and succeeds by default if empty"
                                             (let ((callback-result nil))
                                               (funcall (gptel-tool-function mock-sync-contract-tool)
-                                                       "hello"
-                                                       (lambda (res) (setq callback-result res)))
+                                                       (lambda (res) (setq callback-result res))
+                                                       "hello")
                                               (expect callback-result :to-match "Sync hello")))
 
                                         (it "runs permission-request-hook and aborts if it returns nil"
@@ -701,8 +699,8 @@
                                                           (setq perm-called (list name args))
                                                           nil))
                                               (funcall (gptel-tool-function mock-sync-contract-tool)
-                                                       "hello"
-                                                       (lambda (res) (setq callback-result res)))
+                                                       (lambda (res) (setq callback-result res))
+                                                       "hello")
                                               (expect perm-called :to-equal (list 'mock-sync-contract-tool '(:arg1 "hello")))
                                               (expect callback-result :to-match "Permission denied by macher-agent-permission-request-hook")))
 
@@ -713,8 +711,8 @@
                                                         (lambda (name args result)
                                                           (setq post-called (list name args result))))
                                               (funcall (gptel-tool-function mock-sync-contract-tool)
-                                                       "world"
-                                                       (lambda (res) (setq callback-result res)))
+                                                       (lambda (res) (setq callback-result res))
+                                                       "world")
                                               (expect callback-result :to-match "Sync world")
                                               (expect post-called :to-equal (list 'mock-sync-contract-tool '(:arg1 "world") "Sync world"))))
 
@@ -723,7 +721,7 @@
                                                 "Mock error tool"
                                               :category "test"
                                               :args (list (list :name "arg1" :type 'string))
-                                              :command-fn (lambda (_payload)
+                                              :command-fn (lambda (_payload _context _root)
                                                             (error "Failing intentionally")))
                                             (let ((failure-called nil)
                                                   (callback-result nil))
@@ -731,13 +729,13 @@
                                                         (lambda (name args err)
                                                           (setq failure-called (list name args err))))
                                               (funcall (gptel-tool-function mock-error-tool)
-                                                       "fail"
-                                                       (lambda (res) (setq callback-result res)))
+                                                       (lambda (res) (setq callback-result res))
+                                                       "fail")
                                               (expect callback-result :to-match "Failing intentionally")
                                               (expect (car failure-called) :to-be 'mock-error-tool)
                                               (expect (cadr failure-called) :to-equal '(:arg1 "fail"))
                                               (expect (error-message-string (caddr failure-called)) :to-equal "Failing intentionally"))))
-                              
+
                               (describe "Agent Skills (macher-agent-skills.el)"
                                         (before-each
                                          (spy-on 'macher-agent-resolve-context :and-return-value
@@ -765,18 +763,18 @@
                                               (make-directory mock-script-dir t)
                                               (with-temp-file mock-script-path
                                                 (insert "(setq workspace-tool-1 'workspace-loaded)"))
-                                              
+
                                               ;; Test workspace parsing logic
                                               (macher-agent--load-skill-from-path "tests/fixtures/skills/workspace/" (macher-agent-resolve-context))
                                               (let* ((workspace (macher-agent--get-context-workspace (macher-agent-resolve-context)))
                                                      (skill-meta (alist-get 'workspace-skill (macher-agent-workspace-skills-alist workspace))))
                                                 (expect (plist-get skill-meta :context-dir) :to-be nil))
-                                              
+
                                               ;; Resolution should fail to load because context-dir is nil,
                                               ;; returning the raw string fallback instead of a loaded tool object.
                                               (let ((resolved (macher-agent-resolve-tool "workspace-tool-1" nil nil)))
                                                 (expect resolved :to-equal "workspace-tool-1"))
-                                              
+
                                               (delete-directory mock-script-dir t)))
 
                                         (it "verifies tool resolution hierarchy (workspace shadows package tools)"
@@ -795,21 +793,21 @@
                                               (with-temp-file (expand-file-name "tool-b.el" pkg-scripts) (insert "(setq tool-b mock-pkg-b-global)"))
                                               ;; Workspace overrides tool-a
                                               (with-temp-file (expand-file-name "tool-a.el" ws-scripts) (insert "(setq tool-a mock-ws-a-global)"))
-                                              
+
                                               ;; Clear registry
                                               (let* ((ctx (macher-agent-resolve-context))
                                                      (ws (macher-agent--get-context-workspace ctx)))
                                                 (clrhash (macher-agent-workspace-tools-registry ws)))
-                                              
+
                                               ;; Resolve pkg first, then workspace shadows
                                               (let* ((res-pkg-b (macher-agent-resolve-tool "tool-b" nil pkg-dir))
                                                      (res-ws-a (macher-agent-resolve-tool "tool-a" nil ws-dir)))
                                                 (expect res-pkg-b :to-equal pkg-b)
                                                 (expect res-ws-a :to-equal ws-a))
-                                              
+
                                               (delete-directory pkg-dir t)
                                               (delete-directory ws-dir t)))
-                                        
+
                                         (it "applies skill tools correctly into gptel-tools when selected"
                                             (let* ((gptel-tools nil)
                                                    (gptel--known-presets nil)
@@ -821,10 +819,10 @@
                                               (let* ((ctx (macher-agent-resolve-context))
                                                      (workspace (macher-agent--get-context-workspace ctx)))
                                                 (puthash "selected-tool" mock-tool-obj (macher-agent-workspace-tools-registry workspace))
-                                                
+
                                                 (setf (alist-get 'test-preset (macher-agent-workspace-skills-alist workspace))
                                                       (list :description "test" :system "Directive body" :tools (list mock-tool-obj) :context-dir nil))
-                                                
+
                                                 (with-temp-buffer
                                                   (let ((gptel--known-presets nil))
                                                     (macher-agent-initialize-skills ctx)
@@ -844,7 +842,7 @@
                                                 (let ((gptel-directives nil)
                                                       (gptel--known-presets nil))
                                                   (macher-agent-initialize-skills nil mock-dir)
-                                                  
+
                                                   (let ((preset-def (alist-get 'my-preset gptel--known-presets)))
                                                     (expect preset-def :not :to-be nil)
                                                     (expect (plist-get preset-def :system) :to-equal "Preset body")


### PR DESCRIPTION
Changes based on runtime profiling

- use supported hooks for patch building
- fully move to cons + :data over a struct
- flattened signature resolution
- fix: removed defensive programming
- representative integration tests
  - added tests to simulate buffer writes and subagents
  - full macher context loop integration test
- added character escapes to rsync cmd
- update readme
- Added pre vs post change permission narrative
- json normalisation (NB arrays not covered in gptel)
- tool calling simplification