### PR TITLE
chore(sandbox): rationalised sync/ptc sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ git init
 
 ```
 
-Next, capture a discussion buffer using `macher-discuss` or standard `gptel-mode`. From within this buffer, you can interact with the language model and spin up agents to handle workspace tasks.
+Next, capture a discussion buffer using `macher-discuss` or standard `gptel`. From within this buffer, you can interact with the language model and spin up agents to handle workspace tasks.
 
 ## Documentation and wiki
 

--- a/macher-agent-api.el
+++ b/macher-agent-api.el
@@ -1300,7 +1300,16 @@ Return the result of evaluating EXPRESSION.
 
 Side effects: Evaluates sandboxed Lisp expression."
   (declare (ftype (function (t list) t)))
-  (macher-agent-sandbox--run expression extra-operations))
+  (setq macher-agent-sandbox--primitives (make-hash-table :test 'eq)
+        macher-agent-sandbox--functions (make-hash-table :test 'eq)
+        macher-agent-sandbox--globals (make-hash-table :test 'eq))
+  (macher-agent-sandbox--init extra-operations)
+  (let ((iterator (macher-agent-sandbox--eval-iter (macroexpand-all expression) nil))
+        (yield-val nil))
+    (condition-case err
+        (while t
+          (setq yield-val (iter-next iterator yield-val)))
+      (iter-end-of-sequence (cdr err)))))
 
 (provide 'macher-agent-api)
 ;;; macher-agent-api.el ends here

--- a/macher-agent-gptel-bridge.el
+++ b/macher-agent-gptel-bridge.el
@@ -841,8 +841,8 @@ Side effects: None."
          (authorised-names (mapcar #'macher-agent-canonical-tool-name fsm-tools)))
     (unless (and canonical-name (member canonical-name authorised-names))
       (list
-       :block (format "ERROR: Tool '%s' is out of scope. It was not provided to this \
-sub-agent." (or canonical-name tool))))))
+       :block (format "ERROR: Tool '%s' is not accessible in this context or is no longer available. Please select another tool or approach."
+                      (or canonical-name tool))))))
 
 (defun macher-agent-setup-gptel-buffer ()
   "Set up a gptel buffer with macher-agent capabilities.

--- a/macher-agent-gptel-tools.el
+++ b/macher-agent-gptel-tools.el
@@ -68,7 +68,8 @@ Side effects: None.")
   "Represent a Programmatic Tool Calling response structure.
 
 Return a new `macher-agent-ptc-response' struct instance.
-Side effects: None.")
+Side effects: None."
+  primitives)
 
 ;;; Customisation Variables
 
@@ -684,11 +685,16 @@ Side effects: Evaluates Lisp AST and dispatches tool calls with feedback."
   (condition-case general-err
       (let ((macher-agent--active-ptc-execution t)
             (script-string (macher-agent-tool-response-payload res))
+            (extra-primitives (macher-agent-ptc-response-primitives res))
             (target-buf (or (macher-agent-tool-response-buffer-name res) (current-buffer))))
         (if (not script-string)
             (funcall on-error (list :status 'error :error "Invalid PTC script payload"))
           (let ((ast (macroexpand-all (read script-string))))
             (with-current-buffer target-buf
+              (setq macher-agent-sandbox--primitives (make-hash-table :test 'eq)
+                    macher-agent-sandbox--functions (make-hash-table :test 'eq)
+                    macher-agent-sandbox--globals (make-hash-table :test 'eq))
+              (macher-agent-sandbox--init extra-primitives)
               (let ((iterator (macher-agent-sandbox--eval-iter ast nil)))
                 (if (not iterator)
                     (funcall on-error (list :status 'error :error "Failed to initialise PTC iterator"))
@@ -734,7 +740,11 @@ Side effects: Updates mode-line status and executes pre-tool-call hooks."
                  original-name-str)))
     (message "PTC Executing: %s" desc)
     (when (fboundp 'gptel--update-status)
-      (gptel--update-status (format " PTC: %s..." original-name-str) 'mode-line-emphasis))
+      (gptel--update-status
+       (concat
+        (propertize " Calling PTC tool (" 'face 'mode-line-emphasis)
+        (propertize (format "%s" tool-sym) 'face 'font-lock-keyword-face)
+        (propertize ")" 'face 'mode-line-emphasis))))
     (when (bound-and-true-p gptel-pre-tool-call-functions)
       (run-hook-wrapped 'gptel-pre-tool-call-functions
                         (lambda (f)
@@ -940,7 +950,8 @@ Side effects: Invokes target primitive function or tool callback."
       (when stop-iter-fn (funcall stop-iter-fn))
       (funcall on-error
                (list :status 'error
-                     :error (format "Unknown PTC primitive requested: %s" original-name-str))))))
+                     :error (format "ERROR: Tool '%s' is not accessible in this context or is no longer available. Please select another tool or approach."
+                                    original-name-str))))))
 
 (defun macher-agent--ptc-handle-yielded-value (yielded-val context ptc-resume-loop on-error stop-iter-fn)
   "Handle YIELDED-VAL returned during PTC execution.

--- a/macher-agent-macher-bridge.el
+++ b/macher-agent-macher-bridge.el
@@ -508,7 +508,7 @@ Side effects: Switches current buffer to BUFFER and triggers request completion.
         (macher-agent--with-protected-context-contents agent-ctx
           (funcall process-fn 'complete agent-ctx fsm))))))
 
-(defun macher-agent--trigger-patch-on-complete (fsm)
+(defun macher-agent--trigger-patch-on-complete (fsm &rest _)
   "Trigger patch generation when FSM transitions to DONE state.
 
 Inspect finite-state machine FSM state upon transition.  If state is DONE, resolve

--- a/macher-agent-sandbox.el
+++ b/macher-agent-sandbox.el
@@ -79,8 +79,7 @@ Side effects: Mutates the PRIMITIVES hash-table."
   "Initialise the sandbox environment.
 
 Set up primitives, functions, and globals hash-tables if not already
-initialised, and populate them with standard pure host operations and mapcar
-and mapc helpers.
+initialised, and populate them with standard pure host operations.
 
 EXTRA-OPERATIONS is an optional list of additional primitive symbols to permit.
 
@@ -92,49 +91,10 @@ Side effects: Initialises and mutates buffer-local sandbox state variables."
     (setq macher-agent-sandbox--primitives (make-hash-table :test 'eq)
           macher-agent-sandbox--functions (make-hash-table :test 'eq)
           macher-agent-sandbox--globals (make-hash-table :test 'eq))
-    (macher-agent-sandbox--populate-pure-primitives macher-agent-sandbox--primitives)
-    (puthash 'mapcar (lambda (f seq)
-                       (mapcar (lambda (item) (macher-agent-sandbox--funcall f (list item))) seq))
-             macher-agent-sandbox--primitives)
-    (puthash 'mapc (lambda (f seq)
-                     (mapc (lambda (item) (macher-agent-sandbox--funcall f (list item))) seq) seq)
-             macher-agent-sandbox--primitives))
+    (macher-agent-sandbox--populate-pure-primitives macher-agent-sandbox--primitives))
   (when extra-operations
     (dolist (op extra-operations)
       (puthash op op macher-agent-sandbox--primitives))))
-
-(defun macher-agent-sandbox--step-sync (iterator yield-val)
-  "Advance ITERATOR with YIELD-VAL by one step synchronously.
-
-Evaluate one step of ITERATOR passing YIELD-VAL as input.  Signal an error
-if the step yields an asynchronous PTC tool call interrupt.
-
-ITERATOR is the generator object being stepped.
-YIELD-VAL is the value sent to the iterator on this step.
-
-Return the result form returned or yielded by ITERATOR.
-Side effects: May signal an error if an asynchronous tool call is attempted."
-  (let ((res (iter-next iterator yield-val)))
-    (if (and (consp res) (eq (plist-get res :interrupt) 'tool-call))
-        (error "Execution Error: Script attempted to call async PTC tool '%s' inside a synchronous evaluation context"
-               (plist-get res :name))
-      res)))
-
-(defun macher-agent-sandbox--run-sync (iterator)
-  "Pump ITERATOR to completion synchronously.
-
-Drive ITERATOR step by step until completion, catching `iter-end-of-sequence`
-to extract and return the final value safely.
-
-ITERATOR is the generator object to drive to completion.
-
-Return the final value produced by ITERATOR upon completion.
-Side effects: May signal an error if ITERATOR attempts an asynchronous yield."
-  (condition-case err
-      (let ((yield-val nil))
-        (while t
-          (setq yield-val (macher-agent-sandbox--step-sync iterator yield-val))))
-    (iter-end-of-sequence (cdr err))))
 
 (iter-defun macher-agent-sandbox--eval-args-iter (args env)
   "Evaluate a list of ARGS in ENV using the generator evaluator.
@@ -150,19 +110,6 @@ Side effects: May mutate global sandbox state during evaluation."
   (let ((evaled nil))
     (dolist (arg args (nreverse evaled))
       (push (iter-yield-from (macher-agent-sandbox--eval-iter arg env)) evaled))))
-
-(defun macher-agent-sandbox--eval-args (args env)
-  "Evaluate a list of ARGS in ENV synchronously.
-
-Evaluate each argument form in ARGS sequentially in environment ENV
-and return the resulting list of evaluated values.
-
-ARGS is a list of expressions to evaluate.
-ENV is the current lexical environment alist.
-
-Return a list of evaluated argument values.
-Side effects: May mutate global sandbox state during evaluation."
-  (macher-agent-sandbox--run-sync (macher-agent-sandbox--eval-args-iter args env)))
 
 (iter-defun macher-agent-sandbox--apply-closure-iter (closure arguments)
   "Execute CLOSURE with ARGUMENTS as a generator.
@@ -182,19 +129,6 @@ Side effects: May mutate global sandbox state during execution."
       (push (cons (pop params) (pop arguments)) new-env))
     (dolist (form (caddr closure) result)
       (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form new-env))))))
-
-(defun macher-agent-sandbox--apply-closure (closure arguments)
-  "Execute CLOSURE with ARGUMENTS synchronously.
-
-Bind CLOSURE parameters to evaluated ARGUMENTS in a new environment and
-run the closure body forms to completion synchronously.
-
-CLOSURE is a closure structure (closure PARAMS BODY ENV).
-ARGUMENTS is a list of evaluated argument values to bind.
-
-Return the result of evaluating the final body form in CLOSURE.
-Side effects: May mutate global sandbox state during execution."
-  (macher-agent-sandbox--run-sync (macher-agent-sandbox--apply-closure-iter closure arguments)))
 
 (defun macher-agent-sandbox--normalize-args-to-plist (args)
   "Normalise ARGS into a standard plist for tool calls.
@@ -285,19 +219,6 @@ Side effects: May yield an interrupt or mutate global sandbox state."
    (t
     (error "Invalid function target: %s" func))))
 
-(defun macher-agent-sandbox--funcall (func eval-args)
-  "Execute function FUNC with EVAL-ARGS synchronously.
-
-Dispatch and execute function FUNC with evaluated arguments EVAL-ARGS
-synchronously to completion.
-
-FUNC is a function symbol or closure structure.
-EVAL-ARGS is the list of evaluated argument values.
-
-Return the result of invoking FUNC with EVAL-ARGS.
-Side effects: May mutate global sandbox state during execution."
-  (macher-agent-sandbox--run-sync (macher-agent-sandbox--funcall-iter func eval-args)))
-
 (iter-defun macher-agent-sandbox--eval-single-binding-iter (binding eval-env)
   "Evaluate a single BINDING specification in EVAL-ENV.
 
@@ -334,20 +255,6 @@ Side effects: May mutate global sandbox state during binding evaluation."
                     (macher-agent-sandbox--eval-single-binding-iter binding eval-env))))
         (setq new-env (cons pair new-env))))))
 
-(defun macher-agent-sandbox--bind (bindings env is-star)
-  "Process BINDINGS to extend ENV synchronously.
-
-Evaluate BINDINGS synchronously to construct an extended lexical
-environment from ENV.
-
-BINDINGS is a list of binding specifications.
-ENV is the base lexical environment alist.
-IS-STAR is non-nil for sequential let* binding, or nil for parallel let binding.
-
-Return the extended lexical environment alist.
-Side effects: May mutate global sandbox state during binding evaluation."
-  (macher-agent-sandbox--run-sync (macher-agent-sandbox--bind-iter bindings env is-star)))
-
 (iter-defun macher-agent-sandbox--eval-and-or-iter (args env is-or)
   "Evaluate boolean logic forms ARGS in ENV.
 
@@ -365,20 +272,6 @@ Side effects: May mutate global sandbox state during evaluation."
       (setq result (iter-yield-from (macher-agent-sandbox--eval-iter (pop args) env))))
     result))
 
-(defun macher-agent-sandbox--eval-and-or (args env is-or)
-  "Evaluate boolean logic forms ARGS in ENV synchronously.
-
-Evaluate expressions in ARGS synchronously using short-circuit logic,
-driven by IS-OR for logical OR or logical AND behaviour.
-
-ARGS is a list of conditional expressions.
-ENV is the lexical environment alist.
-IS-OR is non-nil for or forms, or nil for and forms.
-
-Return the result of short-circuit evaluation.
-Side effects: May mutate global sandbox state during evaluation."
-  (macher-agent-sandbox--run-sync (macher-agent-sandbox--eval-and-or-iter args env is-or)))
-
 (iter-defun macher-agent-sandbox--eval-let-iter (args env is-star)
   "Evaluate let or let* form ARGS in ENV.
 
@@ -395,20 +288,6 @@ Side effects: May mutate global sandbox state during evaluation."
         (result nil))
     (dolist (form (cdr args) result)
       (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form new-env))))))
-
-(defun macher-agent-sandbox--eval-let (args env is-star)
-  "Evaluate let or let* form ARGS in ENV synchronously.
-
-Bind variables in (car ARGS) and execute body forms in (cdr ARGS)
-synchronously to completion.
-
-ARGS is a list starting with bindings list followed by body forms.
-ENV is the current lexical environment alist.
-IS-STAR is non-nil for let* binding, or nil for standard let binding.
-
-Return the value of the final body form.
-Side effects: May mutate global sandbox state during evaluation."
-  (macher-agent-sandbox--run-sync (macher-agent-sandbox--eval-let-iter args env is-star)))
 
 (iter-defun macher-agent-sandbox--eval-setq-iter (args env)
   "Evaluate setq form ARGS in ENV.
@@ -433,8 +312,47 @@ Side effects: Mutates variable bindings in ENV or `macher-agent-sandbox--globals
           (puthash var val macher-agent-sandbox--globals))))
     val))
 
+(iter-defun macher-agent-sandbox--eval-mapcar-iter (args env)
+  "Evaluate mapcar form ARGS in ENV.
+
+Evaluate function and sequence expressions in ARGS within environment ENV,
+then map the function over sequence items sequentially.
+
+ARGS is a list starting with function expression followed by sequence.
+ENV is the current lexical environment alist.
+
+Return a list of mapped elements.
+Side effects: May yield tool call interrupts or mutate global sandbox state."
+  (let ((func (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
+        (seq (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env)))
+        (result nil))
+    (unless (listp seq)
+      (error "Execution error (mapcar): Wrong type argument: listp, %s" seq))
+    (dolist (item seq (nreverse result))
+      (push (iter-yield-from (macher-agent-sandbox--funcall-iter func (list item))) result))))
+
+(iter-defun macher-agent-sandbox--eval-mapc-iter (args env)
+  "Evaluate mapc form ARGS in ENV.
+
+Evaluate function and sequence expressions in ARGS within environment ENV,
+then apply the function to sequence items sequentially.
+
+ARGS is a list starting with function expression followed by sequence.
+ENV is the current lexical environment alist.
+
+Return the sequence argument SEQ.
+Side effects: May yield tool call interrupts or mutate global sandbox state."
+  (let ((func (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
+        (seq (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env))))
+    (unless (listp seq)
+      (error "Execution error (mapc): Wrong type argument: listp, %s" seq))
+    (dolist (item seq seq)
+      (iter-yield-from (macher-agent-sandbox--funcall-iter func (list item))))))
+
 (defvar-local macher-agent-sandbox--special-forms
   `((quote . ,(iter-lambda (args _env) (car args)))
+    (mapcar . ,(iter-lambda (args env) (iter-yield-from (macher-agent-sandbox--eval-mapcar-iter args env))))
+    (mapc . ,(iter-lambda (args env) (iter-yield-from (macher-agent-sandbox--eval-mapc-iter args env))))
     (function . ,(iter-lambda (args env)
                    (let ((fn-target (car args)))
                      (if (symbolp fn-target)
@@ -639,36 +557,6 @@ Side effects: May initialise sandbox state and yield on tool interrupts."
     (macher-agent-sandbox--eval-symbol expression environment))
    ((consp expression)
     (iter-yield-from (macher-agent-sandbox--eval-compound-iter expression environment)))))
-
-(defun macher-agent-sandbox--eval (expression environment)
-  "Evaluate EXPRESSION in ENVIRONMENT synchronously.
-
-Evaluate Lisp form EXPRESSION synchronously to completion in ENVIRONMENT.
-
-EXPRESSION is the Lisp form to evaluate.
-ENVIRONMENT is the current lexical environment alist.
-
-Return the evaluated result of EXPRESSION.
-Side effects: May initialise sandbox state and mutate global state."
-  (macher-agent-sandbox--run-sync (macher-agent-sandbox--eval-iter expression environment)))
-
-(defun macher-agent-sandbox--run (expression extra-operations)
-  "Expand EXPRESSION and execute in a sandboxed environment.
-
-Macroexpand EXPRESSION fully, reinitialise sandbox environment tables,
-and evaluate the expanded form in a fresh top-level environment.
-
-EXPRESSION is the Lisp form to expand and evaluate.
-EXTRA-OPERATIONS is an optional list of additional primitive symbols to permit.
-
-Return the result of evaluating EXPRESSION.
-Side effects: Resets and initialises sandbox environment state tables."
-  (let ((expanded-expression (macroexpand-all expression)))
-    (setq macher-agent-sandbox--primitives (make-hash-table :test 'eq)
-          macher-agent-sandbox--functions (make-hash-table :test 'eq)
-          macher-agent-sandbox--globals (make-hash-table :test 'eq))
-    (macher-agent-sandbox--init extra-operations)
-    (macher-agent-sandbox--eval expanded-expression nil)))
 
 (provide 'macher-agent-sandbox)
 ;;; macher-agent-sandbox.el ends here

--- a/macher-agent.el
+++ b/macher-agent.el
@@ -1,7 +1,7 @@
 ;;; macher-agent.el --- Sandboxed, Language-Agnostic AI Workflows -*- lexical-binding: t; -*-
 
 ;; Author: Elijah Charles
-;; Version: 0.8.0.75
+;; Version: 0.8.0.76
 ;; Package-Requires: ((emacs "30.1") (gptel "0.9.9.6") (macher "0.5.2"))
 ;; Keywords: convenience, gptel, llm, macher
 ;; URL: https://github.com/elij/macher-agent

--- a/skills/scripts/ptc_execution.el
+++ b/skills/scripts/ptc_execution.el
@@ -1,16 +1,22 @@
 (macher-agent-make-tool
- macher-agent-ptc-execution-tool
- "Execute an Emacs Lisp orchestration script. Use this to orchestrate multiple tools, spawn agents, and handle \
-complex asynchronous workflows in a single step."
- :category "execution"
- :args
- '((
-    :name "script"
-    :type string
-    :description "The Emacs Lisp script to execute. Use standard let*, mapcar, dolist, and permitted tool \
-primitives."))
- :command-fn
- (lambda (payload context root)
-   (if-let* ((script (plist-get payload :script)))
-       (make-macher-agent-ptc-response :payload script)
-     (error "No script provided for PTC execution"))))
+    macher-agent-ptc-execution-tool
+    "Execute an Emacs Lisp orchestration script. Use this to orchestrate multiple tools, \
+spawn sub-agents, and handle complex asynchronous workflows in a single step."
+  :category "execution"
+  :args
+  '((
+     :name "script"
+     :type string
+     :description "The Emacs Lisp script to execute. Use standard let*, mapcar, dolist, \
+and permitted tool primitives."))
+  :command-fn
+  (lambda (payload _context _root)
+    (if-let*
+        ((script (plist-get payload :script)))
+        (make-macher-agent-ptc-response
+         :payload script
+         :primitives
+         '(
+           nreverse sort delete delq nconc plist-put aset puthash remhash
+           error signal message random emacs-version))
+      (error "No script provided for PTC execution"))))

--- a/skills/scripts/read_buffer_in_workspace.el
+++ b/skills/scripts/read_buffer_in_workspace.el
@@ -1,49 +1,56 @@
 (macher-agent-make-tool
- macher-agent-read-buffer-in-workspace-tool
- "Read the contents of a scoped buffer (ie a buffer in your allowed list)."
- :category "ro"
- :args '((:name "buffer_name" :type string :description "The name of the buffer to read")
-         (:name "offset" :type number :optional t :description "Line number to start reading from (1-based)")
-         (:name "limit" :type number :optional t :description "Number of lines to read")
-         (:name "show_line_numbers" :type boolean :optional t :description "Include line numbers in output"))
- :command-fn
- (lambda (payload context _root)
-   (let* ((buffer_name (plist-get payload :buffer_name))
-          (offset (plist-get payload :offset))
-          (limit (plist-get payload :limit))
-          (show_line_numbers (and (plist-get payload :show_line_numbers)
-                                  (not (eq
-                                        (plist-get payload :show_line_numbers)
-                                        :json-false))))
-          (actual-name (macher-agent--resolve-buffer-name buffer_name))
-          (parsed-offset (when (numberp offset) (round offset)))
-          (parsed-limit (when (numberp limit) (round limit))))
-     (macher-agent--ensure-access context actual-name)
-     (let* ((norm-key (macher-agent--normalize-path-key actual-name context))
-            (contents (macher-agent--get-context-contents context))
-            (entry (or (cl-find norm-key contents :key #'car :test #'equal)
-                       (cl-find actual-name contents :key #'car :test #'equal)))
-            (content (if entry (macher-agent-vfs-entry-curr entry)
-                       (let ((raw-str (cond
-                                       ((get-buffer actual-name)
-                                        (with-current-buffer (get-buffer actual-name)
-                                          (buffer-substring-no-properties (point-min) (point-max))))
-                                       ((and (not (file-name-absolute-p actual-name))
-                                             (not (string-prefix-p "~" actual-name))
-                                             (file-exists-p actual-name))
-                                        (with-temp-buffer
-                                          (insert-file-contents actual-name)
-                                          (buffer-string)))
-                                       (t ""))))
-                         (when context
-                           (let ((old-contents (macher-agent--get-context-contents context)))
-                             (unless (or (cl-find norm-key old-contents :key #'car :test #'equal)
-                                         (cl-find actual-name old-contents :key #'car :test #'equal))
-                               (macher-agent--set-context-contents
-                                context
-                                (cons (macher-agent-vfs-make-entry norm-key raw-str raw-str)
-                                      old-contents)))))
-                         raw-str))))
-       (let ((res-str (macher--read-string
-                       content parsed-offset parsed-limit show_line_numbers)))
-         res-str)))))
+    macher-agent-read-buffer-in-workspace-tool
+    "Read the contents of a scoped buffer (ie a buffer in your allowed list)."
+  :category "perception"
+  :args
+  '((:name "buffer_name" :type string :description "The name of the buffer to read")
+    (
+     :name "offset"
+     :type number :optional t :description "Line number to start reading from (1-based)")
+    (:name "limit" :type number :optional t :description "Number of lines to read")
+    (
+     :name "show_line_numbers"
+     :type boolean :optional t :description "Include line numbers in output"))
+  :command-fn
+  (lambda (payload context _root)
+    (let* ((buffer_name (plist-get payload :buffer_name))
+           (offset (plist-get payload :offset))
+           (limit (plist-get payload :limit))
+           (show_line_numbers (and (plist-get payload :show_line_numbers)
+                                   (not (eq
+                                         (plist-get payload :show_line_numbers)
+                                         :json-false))))
+           (actual-name (macher-agent--resolve-buffer-name buffer_name))
+           (parsed-offset (when (numberp offset) (round offset)))
+           (parsed-limit (when (numberp limit) (round limit))))
+      (macher-agent--ensure-access context actual-name)
+      (let*
+          ((norm-key (macher-agent--normalize-path-key actual-name context))
+           (contents (macher-agent--get-context-contents context))
+           (entry (or (cl-find norm-key contents :key #'car :test #'equal)
+                      (cl-find actual-name contents :key #'car :test #'equal)))
+           (content
+            (if entry (macher-agent-vfs-entry-curr entry)
+              (let ((raw-str (cond
+                              ((get-buffer actual-name)
+                               (with-current-buffer (get-buffer actual-name)
+                                 (buffer-substring-no-properties (point-min) (point-max))))
+                              ((and (not (file-name-absolute-p actual-name))
+                                    (not (string-prefix-p "~" actual-name))
+                                    (file-exists-p actual-name))
+                               (with-temp-buffer
+                                 (insert-file-contents actual-name)
+                                 (buffer-string)))
+                              (t ""))))
+                (when context
+                  (let ((old-contents (macher-agent--get-context-contents context)))
+                    (unless (or (cl-find norm-key old-contents :key #'car :test #'equal)
+                                (cl-find actual-name old-contents :key #'car :test #'equal))
+                      (macher-agent--set-context-contents
+                       context
+                       (cons (macher-agent-vfs-make-entry norm-key raw-str raw-str)
+                             old-contents)))))
+                raw-str))))
+        (let ((res-str (macher--read-string
+                        content parsed-offset parsed-limit show_line_numbers)))
+          res-str)))))

--- a/tests/macher-agent-test.el
+++ b/tests/macher-agent-test.el
@@ -1009,13 +1009,15 @@
                                                    (:buffer "agent-beta" :status success :data "result-beta")))))
 
           (it "safely evaluates synchronous expressions without leaking iter-end-of-sequence"
-              (let ((val (macher-agent-sandbox--eval '(+ 10 20) nil)))
+              (let ((val (macher-agent-sandbox-run '(+ 10 20) nil)))
                 (expect val :to-equal 30)))
 
-          (it "blocks async PTC yields when evaluated in a synchronous context"
-              (let ((macher-agent--active-ptc-primitives '(spawn-subagent)))
-                (expect (macher-agent-sandbox--eval '(spawn-subagent "test" nil) nil)
-                        :to-throw 'error)))
+          (it "yields PTC tool interrupts when evaluated via eval-iter"
+              (let* ((macher-agent--active-ptc-primitives '(spawn-subagent))
+                     (iter (macher-agent-sandbox--eval-iter '(spawn-subagent "test" nil) nil))
+                     (yield-val (iter-next iter)))
+                (expect (plist-get yield-val :interrupt) :to-equal 'tool-call)
+                (expect (plist-get yield-val :name) :to-equal 'spawn-subagent)))
 
           (it "guards against sentinel double-invocation during async tool callbacks"
               (let* ((macher-agent--active-ptc-primitives '(spawn-subagent delegate-tasks-to-subagents read-file))


### PR DESCRIPTION
- yield sanbox used for all lisp
- fsm in aborted state no longer raises error at patch generation
- fonts now match gptel