### PR TITLE
chore(prompt): ground work needed for global directives

### DIFF
--- a/macher-agent-api.el
+++ b/macher-agent-api.el
@@ -252,6 +252,52 @@ Side effects: None."
     (let ((raw-name (macher-agent--extract-raw-tool-name tool)))
       (format "%s" (if (symbolp raw-name) (symbol-name raw-name) raw-name)))))
 
+(defun macher-agent-log-tool-intent (context type target args)
+  "Log tool execution intent entry to CONTEXT audit log.
+
+CONTEXT is the active context structure.
+TYPE is the invocation type string, such as gptel-tool or ptc.
+TARGET is the tool identifier name string or PTC primitive symbol.
+ARGS is the list of parameters passed to the tool.
+
+Return the updated audit log list.
+
+Side effects: Mutates CONTEXT audit log property list."
+  (when context
+    (let* ((log (macher-agent--get-context-data context :audit-log))
+           (preset-sym (bound-and-true-p macher-agent--active-skill-sym))
+           (preset-str (if preset-sym
+                           (if (symbolp preset-sym)
+                               (symbol-name preset-sym)
+                             (format "%s" preset-sym))
+                         "unknown"))
+           (entry `((timestamp . ,(format-time-string "%Y-%m-%dT%H:%M:%S"))
+                    (buffer . ,(buffer-name))
+                    (preset . ,preset-str)
+                    (type . ,type)
+                    (target . ,target)
+                    (args . ,args))))
+      (macher-agent--set-context-data context :audit-log (append log (list entry))))))
+
+(defun macher-agent--log-gptel-pre-tool (tool &optional _fsm &rest args)
+  "Log GPTEL pre-tool call intent to context audit log.
+
+TOOL is the tool structure or property list.
+_FSM is the optional state machine object.
+ARGS represents additional arguments passed to the tool call.
+
+Return nil.
+
+Side effects: Appends tool call entry to active context audit log."
+  (let ((context (ignore-errors (macher-agent-resolve-context)))
+        (tool-name (macher-agent-canonical-tool-name tool))
+        (tool-args (if (and (listp tool) (plist-member tool :args))
+                       (plist-get tool :args)
+                     args)))
+    (macher-agent-log-tool-intent context "gptel-tool" tool-name tool-args)))
+
+(add-hook 'gptel-pre-tool-call-functions #'macher-agent--log-gptel-pre-tool)
+
 (defun macher-agent--cache-tool (tool registry)
   "Cache TOOL in REGISTRY using its canonical string name.
 
@@ -921,6 +967,8 @@ Side effects: None."
                 if (equal prompt sys-msg)
                 return (symbol-name sym))))))
 
+(make-obsolete 'macher-agent--get-system-message-name nil "0.4.0")
+
 (defun macher-agent-initialize-skills (&optional context dir)
   "Initialise agent skills from all registered directories and contexts.
 
@@ -974,10 +1022,7 @@ Side effects: Registers skills, configures directives, and sets up menus."
                     (setf (alist-get sym gptel-directives) system-prompt)
                     (let ((preset-spec (list :description (or desc (format "Agent Profile: %s" sym))
                                              :system system-prompt)))
-                      (when exclusive
-                        (setq preset-spec (plist-put preset-spec :exclusive t)))
                       (when model (setq preset-spec (plist-put preset-spec :model model)))
-                      (when ptc-primitives (setq preset-spec (plist-put preset-spec :ptc-primitives ptc-primitives)))
                       (when tool-names
                         (setq preset-spec (plist-put preset-spec :tools
                                                      (if exclusive
@@ -1283,10 +1328,18 @@ Side effects: Creates new chat buffer and sets buffer-local agent variables."
 
       (setq-local macher-agent-parent-buffer parent-name)
 
-      (when active-backend (setq-local gptel-backend active-backend))
-      (when active-model (setq-local gptel-model active-model))
-      (when active-sys (setq-local gptel-system-prompt active-sys))
-      (when active-skill (setq-local macher-agent--active-skill-sym active-skill))
+      (when-let* ((backend active-backend))
+        (setq-local gptel-backend backend))
+      (when-let* ((model active-model))
+        (setq-local gptel-model model))
+      (when-let* ((sys active-sys))
+        (setq-local gptel-system-prompt sys))
+      (when-let* ((skill active-skill))
+        (setq-local macher-agent--active-skill-sym skill))
+
+      (setq-local macher-agent-presets (with-current-buffer parent-buf macher-agent-presets))
+      (setq-local macher-agent--active-ptc-primitives (with-current-buffer parent-buf macher-agent--active-ptc-primitives))
+      (setq-local gptel-tools (with-current-buffer parent-buf gptel-tools))
 
       (switch-to-buffer (current-buffer)))))
 
@@ -1304,11 +1357,20 @@ Side effects: Evaluates sandboxed Lisp expression."
         macher-agent-sandbox--functions (make-hash-table :test 'eq)
         macher-agent-sandbox--globals (make-hash-table :test 'eq))
   (macher-agent-sandbox--init extra-operations)
-  (let ((iterator (macher-agent-sandbox--eval-iter (macroexpand-all expression) nil))
-        (yield-val nil))
+  (let ((context (ignore-errors (macher-agent-resolve-context)))
+        (iterator (macher-agent-sandbox--eval-iter (macroexpand-all expression) nil))
+        (yield-val nil)
+        (next-yield nil))
     (condition-case err
         (while t
-          (setq yield-val (iter-next iterator yield-val)))
+          (setq next-yield (iter-next iterator yield-val))
+          (when (consp next-yield)
+            (let ((target (or (plist-get next-yield :target)
+                              (plist-get next-yield :name)
+                              (car next-yield)))
+                  (args (plist-get next-yield :args)))
+              (macher-agent-log-tool-intent context "ptc" target args)))
+          (setq yield-val next-yield))
       (iter-end-of-sequence (cdr err)))))
 
 (provide 'macher-agent-api)

--- a/macher-agent-gptel-bridge.el
+++ b/macher-agent-gptel-bridge.el
@@ -249,29 +249,26 @@ Keep everything within a let*. Return the output object without formatting.\n"))
 
 Scan for inline skill tags starting at PROMPT-START and strip matched
 tags from current buffer.  ORIG-BUF is the original buffer used to locate
-fallback directives if no inline skills were matched.
+known skills for validation.
 
 Return a cons cell (MATCHED-SKILLS . INLINE-PRESET-USED).
 Side effects: Modifies buffer text by stripping matched inline tags."
   (let ((matched-skills nil)
-        (inline-preset-used nil))
+        (inline-preset-used nil)
+        (known (with-current-buffer orig-buf (bound-and-true-p gptel--known-presets))))
     (save-excursion
       (goto-char prompt-start)
       (while (re-search-forward "@\\([[:alnum:]_-]+\\)" nil t)
         (when (or (= (match-beginning 0) (point-min))
                   (memq (char-before (match-beginning 0)) '(?\s ?\t ?\n ?\r ?>)))
-          (setq inline-preset-used t)
-          (push (intern (match-string-no-properties 1)) matched-skills)
-          (replace-match "")
-          (when (looking-at "[ \t]+")
-            (replace-match "")))))
-    (unless matched-skills
-      (let ((active-sys (with-current-buffer orig-buf gptel-system-prompt))
-            (directives (with-current-buffer orig-buf gptel-directives)))
-        (when-let* ((sym (cl-loop for (s . sys) in directives
-                                  when (equal sys active-sys) return s)))
-          (push sym matched-skills))))
-    (cons matched-skills inline-preset-used)))
+          (let ((sym (intern (match-string-no-properties 1))))
+            (when (assoc sym known)
+              (setq inline-preset-used t)
+              (push sym matched-skills)
+              (replace-match "")
+              (when (looking-at "[ \t]+")
+                (replace-match "")))))))
+    (cons (nreverse matched-skills) inline-preset-used)))
 
 (defun macher-agent--update-fsm-info-from-payload (fsm payload)
   "Update FSM info plist with keys from PAYLOAD if FSM is non-nil.
@@ -283,7 +280,7 @@ Return updated info plist, or nil if FSM or PAYLOAD is nil.
 Side effects: Mutates info property list of FSM state machine object."
   (when (and fsm payload)
     (let ((new-info (copy-sequence (gptel-fsm-info fsm))))
-      (dolist (key '(:system :model :temperature :max-tokens :tools))
+      (dolist (key '(:system :model :temperature :max-tokens :tools :ptc-primitives))
         (when (plist-member payload key)
           (setq new-info (plist-put new-info key (plist-get payload key)))))
       (setf (gptel-fsm-info fsm) new-info))))
@@ -309,6 +306,8 @@ Side effects: Modifies buffer region and updates info property list of FSM."
       (delete-region prompt-start (point-max))
       (insert sys-prompt)
       (when fsm
+        (when (fboundp 'gptel-fsm-prompt)
+          (setf (gptel-fsm-prompt fsm) sys-prompt))
         (setf (gptel-fsm-info fsm)
               (plist-put (gptel-fsm-info fsm) :prompt sys-prompt))))))
 
@@ -421,29 +420,15 @@ Side effects: Truncates context history in temporary prompt buffer."
   "Synchronise the VFS and normalise the active tools list.
 Compose skill profiles securely.
 
-This function acts exclusively as a pre-wire transformer.  It executes
-within the temporary transmission buffer managed by the system.
-
-It parses and strips inline skill tags locally, preventing destructive
-side effects to the user's source buffer.  It then invokes the
-composition engine to merge the base state with the inline presets,
-applying the resulting transmission state ephemerally before network dispatch.
-
-The payload is applied to buffer variables first, and the finite state machine
-property list is subsequently updated directly.
-
-When an inline skill is used without a prompt its body becomes a prompt
-within the hidden buffer, behaving like a command.
-
-ASYNC-FN is a function to call asynchronously.
-FSM is the finite-state machine.
-
-Return the result of ASYNC-FN."
+It delegates inline skill extraction to `macher-agent--extract-inline-skills`,
+updates operational state in the source buffer, and applies compiled
+transmission state locally to the temporary transmission buffer and FSM."
   (let* ((temp-buf (current-buffer))
          (info (when fsm (gptel-fsm-info fsm)))
          (orig-buf (or (when info (plist-get info :buffer)) temp-buf))
          (macher-agent--allow-lazy-init t)
-         (ctx (macher-agent-resolve-context fsm)))
+         (ctx (with-current-buffer orig-buf
+                (macher-agent-resolve-context fsm))))
 
     (when (and fsm ctx)
       (setf (gptel-fsm-info fsm)
@@ -454,111 +439,93 @@ Return the result of ASYNC-FN."
         (macher-agent--auto-sync-context ctx)
         (macher-agent-initialize-skills ctx)))
 
-    (let ((matched-skills nil)
-          (inline-preset-used nil)
-          (prompt-start (save-excursion
-                          (goto-char (or (previous-single-property-change (point-max) 'gptel) (point-min)))
-                          (point))))
+    (let* ((prompt-start (save-excursion
+                           (goto-char (or (previous-single-property-change (point-max) 'gptel)
+                                          (point-min)))
+                           (point)))
+           (extraction (macher-agent--extract-inline-skills prompt-start orig-buf))
+           (inline-skills (car extraction))
+           (inline-preset-used (cdr extraction)))
 
-      (save-excursion
-        (goto-char prompt-start)
-        (while (re-search-forward "@\\([[:alnum:]_-]+\\)" nil t)
-          (when (or (= (match-beginning 0) (point-min))
-                    (memq (char-before (match-beginning 0)) '(?\s ?\t ?\n ?\r ?>)))
-            (setq inline-preset-used t)
-            (push (intern (match-string-no-properties 1)) matched-skills)
-            (replace-match "")
-            (when (looking-at "[ \t]+")
-              (replace-match "")))))
+      (with-current-buffer orig-buf
+        (let* ((existing (bound-and-true-p macher-agent-presets))
+               (active-sys (bound-and-true-p gptel-system-prompt))
+               (directives (bound-and-true-p gptel-directives))
+               (ui-fallback-sym nil))
 
-      (when matched-skills
-        (with-current-buffer orig-buf
-          (setq-local macher-agent-presets 
-                      (delete-dups (append (bound-and-true-p macher-agent-presets) 
-                                           (reverse matched-skills))))))
+          (when (and (null existing) active-sys)
+            (setq ui-fallback-sym (cl-loop for (s . sys) in directives
+                                           when (equal sys active-sys) return s)))
 
-      (let* ((active-presets (with-current-buffer orig-buf (bound-and-true-p macher-agent-presets)))
-             (active-sys (with-current-buffer orig-buf gptel-system-prompt))
-             (directives (with-current-buffer orig-buf gptel-directives))
-             (clean-sys (if (and active-sys (string-match "\\`\\(\\(?:.\\|\n\\)*?\\)\n\n=== PROGRAMMATIC TOOL CALLING" active-sys))
-                            (string-trim (match-string 1 active-sys))
-                          active-sys)))
+          (when ui-fallback-sym
+            (setq-local macher-agent-presets (list ui-fallback-sym)))))
 
-        (unless matched-skills
-          (if active-presets
-              (setq matched-skills (if (listp active-presets)
-                                       (append matched-skills active-presets)
-                                     (append matched-skills (list active-presets))))
-            (when-let* ((sym (cl-loop for (s . sys) in directives
-                                      when (equal sys clean-sys) return s)))
-              (push sym matched-skills))))
+      (let* ((buffer-presets (with-current-buffer orig-buf (bound-and-true-p macher-agent-presets)))
+             (known (with-current-buffer orig-buf (bound-and-true-p gptel--known-presets)))
 
-        (let ((redirected-skill nil))
-          (when inline-preset-used
-            (let ((remaining-text (buffer-substring-no-properties prompt-start (point-max))))
-              (unless (string-match-p "[A-Za-z]" remaining-text)
-                (setq redirected-skill (pop matched-skills)))))
+             (transmission-skills (let* ((combined (delete-dups (append buffer-presets inline-skills)))
+                                         (acc nil))
+                                    (dolist (p combined (nreverse acc))
+                                      (if (when-let* ((spec (alist-get p known)))
+                                            (plist-get spec :exclusive))
+                                          (setq acc (list p))
+                                        (push p acc)))))
+             (redirected-skill nil))
 
-          (when (let ((base-state
-                       (with-current-buffer orig-buf
-                         (list :model gptel-model
-                               :system clean-sys 
-                               :temperature (bound-and-true-p gptel-temperature)
-                               :max-tokens (bound-and-true-p gptel-max-tokens)
-                               :tools gptel-tools
-                               :known-presets (bound-and-true-p gptel--known-presets))))))
-            
-            (let* ((remaining-skills (nreverse matched-skills))
-                   (all-skills (if redirected-skill
-                                   (append remaining-skills (list redirected-skill))
-                                 remaining-skills))
-                   (payload (when all-skills
-                              (macher-agent-compose-payload base-state all-skills))))
+        (when inline-preset-used
+          (let ((remaining-text (buffer-substring-no-properties prompt-start (point-max))))
+            (unless (string-match-p "[A-Za-z0-9]" remaining-text)
+              (when-let* ((skill (car inline-skills)))
+                (setq redirected-skill skill)))))
 
-              (when payload
-                (let*
-                    ((sys-payload
-                      (when remaining-skills
-                        (macher-agent-compose-payload base-state remaining-skills)))
-                     (final-sys-prompt (if sys-payload
-                                           (plist-get sys-payload :system)
-                                         (plist-get base-state :system)))
-                     (composed-active (plist-get payload :ptc-primitives))
-                     (composed-tools (plist-get payload :tools)))
+        (let* ((clean-sys (with-current-buffer orig-buf
+                            (let ((sys gptel-system-prompt))
+                              (if (and sys (string-match "\\`\\(\\(?:.\\|\n\\)*?\\)\n\n=== PROGRAMMATIC TOOL CALLING" sys))
+                                  (string-trim (match-string 1 sys))
+                                sys))))
+               (base-state (with-current-buffer orig-buf
+                             (list :model gptel-model
+                                   :system clean-sys
+                                   :temperature (bound-and-true-p gptel-temperature)
+                                   :max-tokens (bound-and-true-p gptel-max-tokens)
+                                   :tools gptel-tools
+                                   :known-presets (bound-and-true-p gptel--known-presets))))
 
-                  (setq payload
-                        (plist-put payload
-                                   :system
-                                   (macher-agent--inject-ptc-prompt
-                                    final-sys-prompt composed-active composed-tools))))
+               (buffer-payload (when buffer-presets
+                                 (macher-agent-compose-payload base-state buffer-presets)))
+               (ephemeral-payload (when transmission-skills
+                                    (macher-agent-compose-payload base-state transmission-skills)))
+               (effective-payload (or ephemeral-payload base-state)))
 
-                (macher-agent--apply-payload-locally payload)
+          (when buffer-payload
+            (with-current-buffer orig-buf
+              (let ((safe-payload (copy-sequence buffer-payload)))
+                (setq safe-payload (plist-put safe-payload :system clean-sys))
+                (macher-agent--apply-payload-locally safe-payload))))
 
-                (when fsm
-                  (let ((new-info (copy-sequence (gptel-fsm-info fsm))))
-                    (dolist (key '(:system :model :temperature :max-tokens :tools))
-                      (when (plist-member payload key)
-                        (setq new-info (plist-put new-info key (plist-get payload key)))))
-                    (setf (gptel-fsm-info fsm) new-info))))
+          (when redirected-skill
+            (let* ((skills-without-redirect (remove redirected-skill transmission-skills))
+                   (sys-only-payload (if skills-without-redirect
+                                         (macher-agent-compose-payload base-state skills-without-redirect)
+                                       base-state)))
+              (setq effective-payload (plist-put effective-payload :system (plist-get sys-only-payload :system)))))
 
-              (when redirected-skill
-                (when-let* ((dummy-base (plist-put (copy-sequence base-state) :system ""))
-                            (dummy-payload
-                             (macher-agent-compose-payload dummy-base
-                                                           (list redirected-skill)))
-                            (sys-prompt (plist-get dummy-payload :system))
-                            ((stringp sys-prompt))
-                            ((not (string-empty-p sys-prompt))))
-                  (delete-region prompt-start (point-max))
-                  (insert sys-prompt)
-                  (when fsm
-                    (setf (gptel-fsm-info fsm)
-                          (plist-put (gptel-fsm-info fsm) :prompt sys-prompt))))))
-            t))
+          (let* ((compiled-sys (macher-agent--inject-ptc-prompt
+                                (plist-get effective-payload :system)
+                                (plist-get effective-payload :ptc-primitives)
+                                (plist-get effective-payload :tools)))
+                 (transmission-payload (plist-put (copy-sequence effective-payload)
+                                                  :system compiled-sys)))
+            (macher-agent--apply-payload-locally transmission-payload)
+            (when fsm
+              (macher-agent--update-fsm-info-from-payload fsm transmission-payload)))
 
-        (when-let* ((fn async-fn)
-                    ((functionp fn)))
-          (funcall fn))))))
+          (when redirected-skill
+            (macher-agent--process-redirected-skill redirected-skill base-state prompt-start fsm))))
+
+      (when-let* ((fn async-fn)
+                  ((functionp fn)))
+        (funcall fn)))))
 
 ;;; Transmission and Sub-Agent Reaping
 
@@ -625,7 +592,8 @@ calls `gptel-send'."
          (error-cb (plist-get callbacks :on-error)))
 
     (with-current-buffer target-buffer
-      (setq-local gptel-system-prompt (macher-agent--inject-ptc-prompt sys-msg))
+      (when sys-msg
+        (setq-local gptel-system-prompt sys-msg))
       (add-hook 'gptel-post-response-functions
                 (macher-agent--make-transmit-response-hook success-cb error-cb)
                 nil t)
@@ -725,7 +693,8 @@ RAW is an optional boolean flag.
 
 Return result of calling ORIG-FUN.
 Side effects: None."
-  (funcall orig-fun (or response "") info raw))
+  (when (or response (plist-get info :tool-use))
+    (funcall orig-fun (or response "") info raw)))
 
 (advice-add 'gptel--insert-response :around #'macher-agent--protect-nil-responses)
 (advice-add 'gptel-curl--stream-insert-response :around #'macher-agent--protect-nil-responses)
@@ -892,7 +861,7 @@ Side effects: Global dynamic binding variable.")
   "Capture FSM state machine during tool handling execution.
 
 Bind `macher-agent--active-fsm' dynamically around ORIG-FN invocation.
-ORIG-FN is the original tool handler function.
+ORIG-FUN is the original tool handler function.
 FSM is the active state machine structure.
 ARGS represents additional arguments passed to ORIG-FN.
 

--- a/macher-agent-gptel-tools.el
+++ b/macher-agent-gptel-tools.el
@@ -563,21 +563,21 @@ Side effects: Sets `NAME-SYMBOL' variable to constructed gptel tool object."
                 (let* ((wrap-cb (macher-agent--wrap-callback callback))
                        (payload (macher-agent--extract-payload tool-args ,args)))
                   (macher-agent--with-tool-error-handling ',name-symbol payload wrap-cb
-                    (macher-agent--validate-payload payload ,args)
-                    (let* ((context (or (ignore-errors (macher-agent-resolve-context))
-                                        (bound-and-true-p macher-agent--persistent-context)))
-                           (root (if context (macher-agent-context-root context) default-directory))
-                           (hook-rejection (macher-agent--run-pre-hooks ',name-symbol payload)))
-                      (if hook-rejection
-                          (funcall wrap-cb (list :status 'error :error hook-rejection))
-                        (let* ((action (funcall ,command-fn payload context root))
-                               (action-res (if (macher-agent-tool-response-p action)
-                                               action
-                                             (make-macher-agent-lisp-result-response
-                                              :payload action)))
-                               (on-success (macher-agent--build-success-callback
-                                            ',name-symbol payload ,success-fn ,output-filter-fn wrap-cb)))
-                          (macher-agent-execute-response action-res context on-success wrap-cb))))))))))))
+                                                          (macher-agent--validate-payload payload ,args)
+                                                          (let* ((context (or (ignore-errors (macher-agent-resolve-context))
+                                                                              (bound-and-true-p macher-agent--persistent-context)))
+                                                                 (root (if context (macher-agent-context-root context) default-directory))
+                                                                 (hook-rejection (macher-agent--run-pre-hooks ',name-symbol payload)))
+                                                            (if hook-rejection
+                                                                (funcall wrap-cb (list :status 'error :error hook-rejection))
+                                                              (let* ((action (funcall ,command-fn payload context root))
+                                                                     (action-res (if (macher-agent-tool-response-p action)
+                                                                                     action
+                                                                                   (make-macher-agent-lisp-result-response
+                                                                                    :payload action)))
+                                                                     (on-success (macher-agent--build-success-callback
+                                                                                  ',name-symbol payload ,success-fn ,output-filter-fn wrap-cb)))
+                                                                (macher-agent-execute-response action-res context on-success wrap-cb))))))))))))
 
 ;;; Response Execution Methods
 
@@ -739,7 +739,7 @@ Side effects: Updates mode-line status and executes pre-tool-call hooks."
                    (gptel-tool-description resolved-tool)
                  original-name-str))
          (block-reason nil))
-    
+
     (when (bound-and-true-p gptel-pre-tool-call-functions)
       (run-hook-wrapped 'gptel-pre-tool-call-functions
                         (lambda (f)
@@ -748,7 +748,7 @@ Side effects: Updates mode-line status and executes pre-tool-call hooks."
                             (when (and res (listp res) (plist-get res :block))
                               (setq block-reason (plist-get res :block))
                               t)))))
-    
+
     (if block-reason
         (error "%s" block-reason)
       (message "PTC Executing: %s"

--- a/macher-agent-macher-bridge.el
+++ b/macher-agent-macher-bridge.el
@@ -244,7 +244,7 @@ Side effects: Generates and displays patch buffers and updates CTX prompt."
                    ((and context (not (macher-context-p context))) context)
                    (fsm fsm)
                    (t (macher-agent--get-fsm-latest)))))
-    
+
     (when (and ctx (null (macher-agent--get-context-prompt ctx)))
       (when-let* ((info (when (and fsm-obj (fboundp 'gptel-fsm-info))
                           (ignore-errors (gptel-fsm-info fsm-obj))))
@@ -450,7 +450,7 @@ Side effects: Mutates function slot of TOOL and updates `macher-agent--wrapped-t
                     (when-let* ((user-prompt (macher-context-prompt orphaned-context)))
                       (ignore-errors (setf (macher-context-prompt agent-ctx) user-prompt))
                       (macher-agent--set-context-data agent-ctx :prompt user-prompt)))
-                  
+
                   (macher-agent--inject-context-into-fsm-info agent-ctx))
                 (with-current-buffer target-buf
                   (apply orig-fn (or agent-ctx orphaned-context) callback args)))))
@@ -505,7 +505,7 @@ Side effects: Switches current buffer to BUFFER and triggers request completion.
       (when-let* ((agent-ctx (bound-and-true-p macher-agent--persistent-context))
                   (process-fn (bound-and-true-p macher-process-request-function)))
         (macher-agent--with-protected-context-contents agent-ctx
-          (funcall process-fn 'complete agent-ctx fsm))))))
+                                                       (funcall process-fn 'complete agent-ctx fsm))))))
 
 (defvar macher-agent--inhibit-patch-hook nil)
 

--- a/macher-agent-orchestration.el
+++ b/macher-agent-orchestration.el
@@ -14,11 +14,13 @@
 (require 'macher-agent-gptel-tools)
 (require 'generator)
 (require 'subr-x)
+(require 'cl-lib)
 
 (declare-function macher-agent-gptel-transmit "macher-agent-gptel-bridge" (task-context callbacks))
 (declare-function macher-agent-sync-prompt-transformer "macher-agent-gptel-bridge" (async-fn fsm))
 (declare-function macher-agent-post-response-reaper "macher-agent-gptel-bridge" (beg end))
-(declare-function macher-agent-resolve-context "macher-agent-vfs-client")
+(declare-function macher-agent--enforce-tool-scope "macher-agent-gptel-bridge" (tool &optional fsm &rest args))
+(declare-function macher-agent-resolve-context "macher-agent-vfs-client" (&optional ctx-or-fsm))
 (declare-function macher-agent--inject-context-state "macher-agent-vfs-client" (context &optional directives))
 (declare-function macher-agent--init-workspace-state "macher-agent-vfs-client")
 (declare-function macher-agent--auto-sync-context "macher-agent-vfs-client" (&optional ctx fsm))
@@ -29,6 +31,20 @@
 (declare-function macher-agent-sandbox--eval-iter "macher-agent-sandbox" (ast env))
 (declare-function macher-agent--read-file-vfs-aware "macher-agent-gptel-tools" (file-path context))
 (declare-function macher-agent-context-root "macher-agent-vfs-client" (context))
+(declare-function macher-agent--merge-contexts "macher-agent-vfs-client" (parent-ctx child-ctx))
+(declare-function macher-agent--clone-context "macher-agent-vfs-client" (ctx))
+(declare-function macher-agent--get-context-workspace "macher-agent-vfs-client" (ctx))
+(declare-function macher-agent--get-context-contents "macher-agent-vfs-client" (ctx))
+(declare-function macher-agent-workspace-active-subagents "macher-agent-vfs-client" (ws-or-ctx))
+(declare-function macher-agent--set-workspace-active-subagents "macher-agent-vfs-client" (ws-or-ctx val))
+(declare-function macher-agent-vfs-entry-path "macher-agent-vfs-client" (entry))
+(declare-function macher-agent-vfs-entry-curr "macher-agent-vfs-client" (entry))
+(declare-function macher-context-p "macher-agent-macher-bridge" (ctx))
+(declare-function macher-agent--show-ui "macher-agent-gptel-tools" (buf))
+(declare-function make-macher-agent-delegate-response "macher-agent-gptel-tools" (&rest args))
+(declare-function gptel-abort "gptel" (&optional buffer))
+(declare-function gptel-get-tool "gptel" (name))
+(declare-function gptel--modify-value "gptel" (value modification))
 
 (defvar macher-agent-submit-task-result-tool nil
   "Store the tool object for task result submission.
@@ -54,6 +70,33 @@ Side effects: None."
   target-buffer
   skill-sym
   system-message)
+
+(defun macher-agent--resolve-buffer-name (name)
+  "Resolve buffer string or buffer object NAME to a buffer name string.
+
+NAME is a buffer object, string buffer name, or file path.
+
+Return the resolved buffer name string, or NAME if string and unmapped.
+
+Side effects: None."
+  (cond
+   ((bufferp name) (buffer-name name))
+   ((stringp name)
+    (or (when-let* ((buf (get-buffer name)))
+          (buffer-name buf))
+        (when-let* ((buf (get-file-buffer name)))
+          (buffer-name buf))
+        (when-let* ((buf (get-file-buffer (expand-file-name name))))
+          (buffer-name buf))
+        (cl-some (lambda (buf)
+                   (when (or (equal (buffer-name buf) name)
+                             (and (buffer-file-name buf)
+                                  (or (equal (buffer-file-name buf) name)
+                                      (equal (buffer-file-name buf) (expand-file-name name)))))
+                     (buffer-name buf)))
+                 (buffer-list))
+        name))
+   (t name)))
 
 (defun macher-agent--handle-parallel-task-result (idx result completed-flags results counter-box total final-callback)
   "Record RESULT for task IDX, updating COMPLETED-FLAGS and RESULTS.
@@ -266,7 +309,7 @@ Side effects: None."
                (setq state (plist-put state :ptc-primitives
                                       (cl-delete-duplicates (append current-ptc ptc-list) :test #'equal)))))
 
-           (dolist (key '(:model :temperature :max-tokens))
+           (dolist (key '(:model :backend :temperature :max-tokens))
              (when-let* ((val (plist-get spec key)))
                (setq state (plist-put state key val))))))
 
@@ -290,11 +333,18 @@ Return nil.
 
 Side effects: Sets buffer-local values for gptel and PTC variables."
   (when payload
-    (when (plist-member payload :system) (setq-local gptel-system-prompt (plist-get payload :system)))
-    (when (plist-member payload :model) (setq-local gptel-model (plist-get payload :model)))
-    (when (plist-member payload :temperature) (setq-local gptel-temperature (plist-get payload :temperature)))
-    (when (plist-member payload :max-tokens) (setq-local gptel-max-tokens (plist-get payload :max-tokens)))
-    (when (plist-member payload :tools) (setq-local gptel-tools (plist-get payload :tools)))
+    (when (plist-member payload :system)
+      (setq-local gptel-system-prompt (plist-get payload :system)))
+    (when (plist-member payload :model)
+      (setq-local gptel-model (plist-get payload :model)))
+    (when (plist-member payload :backend)
+      (setq-local gptel-backend (plist-get payload :backend)))
+    (when (plist-member payload :temperature)
+      (setq-local gptel-temperature (plist-get payload :temperature)))
+    (when (plist-member payload :max-tokens)
+      (setq-local gptel-max-tokens (plist-get payload :max-tokens)))
+    (when (plist-member payload :tools)
+      (setq-local gptel-tools (plist-get payload :tools)))
     (when (plist-member payload :ptc-primitives)
       (setq-local macher-agent--active-ptc-primitives (plist-get payload :ptc-primitives)))))
 
@@ -310,12 +360,22 @@ Side effects: Updates buffer-local gptel and PTC settings."
                         ((vectorp preset-or-presets) (append preset-or-presets nil))
                         (t (list preset-or-presets))))
          (base-state (list :model gptel-model
+                           :backend (bound-and-true-p gptel-backend)
                            :system (bound-and-true-p gptel-system-prompt)
                            :temperature (bound-and-true-p gptel-temperature)
                            :max-tokens (bound-and-true-p gptel-max-tokens)
                            :tools gptel-tools
                            :known-presets (bound-and-true-p gptel--known-presets)))
          (payload (macher-agent-compose-payload base-state presets)))
+
+    (when presets
+      (let* ((primary-sym (macher-agent--extract-first-preset-symbol presets))
+             (known (plist-get base-state :known-presets))
+             (spec (when primary-sym (alist-get primary-sym known)))
+             (raw-sys (or (plist-get spec :system) (plist-get spec :system-message))))
+        (when (stringp raw-sys)
+          (setq payload (plist-put payload :system raw-sys)))))
+
     (macher-agent--apply-payload-locally payload)))
 
 (defvar macher-agent--is-subagent nil
@@ -422,8 +482,17 @@ Return t if SYM is an active primitive, otherwise nil.
 Side effects: None."
   (let* ((sym-name (symbol-name sym))
          (norm-sym (replace-regexp-in-string "_" "-" sym-name))
-         (active (bound-and-true-p macher-agent--active-ptc-primitives))
-         (tools (bound-and-true-p gptel-tools)))
+
+         (fsm-obj (or (bound-and-true-p macher-agent--active-fsm)
+                      (bound-and-true-p macher--fsm-latest)
+                      (bound-and-true-p gptel--fsm-last)))
+         (info (when fsm-obj (gptel-fsm-info fsm-obj)))
+
+         (active (or (when info (plist-get info :ptc-primitives))
+                     (bound-and-true-p macher-agent--active-ptc-primitives)))
+         (tools (or (when info (plist-get info :tools))
+                    (bound-and-true-p gptel-tools))))
+
     (and (or (memq sym active)
              (cl-some (lambda (prim)
                         (let* ((prim-name (if (symbolp prim) (symbol-name prim) prim))
@@ -491,13 +560,18 @@ RESOLVED-PRESETS is a string, symbol, list, or vector of presets.
 Return the clean symbol, or nil.
 
 Side effects: None."
-  (let ((first-preset (cond ((stringp resolved-presets) resolved-presets)
-                            ((symbolp resolved-presets) (symbol-name resolved-presets))
-                            ((and (listp resolved-presets) (stringp (car resolved-presets))) (car resolved-presets))
-                            ((and (vectorp resolved-presets) (> (length resolved-presets) 0) (stringp (aref resolved-presets 0))) (aref resolved-presets 0))
-                            (t nil))))
-    (when first-preset
-      (intern (replace-regexp-in-string "^@+" "" first-preset)))))
+  (when-let* ((first-preset (cond ((stringp resolved-presets) resolved-presets)
+                                  ((symbolp resolved-presets) (symbol-name resolved-presets))
+                                  ((and (listp resolved-presets) (car resolved-presets))
+                                   (if (symbolp (car resolved-presets))
+                                       (symbol-name (car resolved-presets))
+                                     (car resolved-presets)))
+                                  ((and (vectorp resolved-presets) (> (length resolved-presets) 0))
+                                   (if (symbolp (aref resolved-presets 0))
+                                       (symbol-name (aref resolved-presets 0))
+                                     (aref resolved-presets 0)))
+                                  (t nil))))
+    (intern (replace-regexp-in-string "^@+" "" first-preset))))
 
 (defun macher-agent--merge-subagent-parent-context (buf parent-buf)
   "Merge persistent context from child BUF into PARENT-BUF.
@@ -537,6 +611,137 @@ Side effects: Returns a closure that updates parent context and reaper state."
               (setq-local macher-agent--ready-to-reap t))))
         (funcall callback res)))))
 
+(defun macher-agent-add-subagent (name &optional presets parent-buf dir context)
+  "Interactively or programmatically create sub-agent buffer NAME.
+
+NAME is the target sub-agent buffer name string.
+PRESETS is optional preset specification, list, vector, or string.
+PARENT-BUF is optional parent orchestrator buffer.
+DIR is optional directory path string.
+CONTEXT is optional VFS context structure.
+
+Return the created sub-agent buffer object.
+
+Side effects: Creates buffer, updates local state, registers in global tracking lists."
+  (interactive "sSub-agent name: ")
+  (let ((actual-presets presets)
+        (actual-parent parent-buf)
+        (actual-dir dir)
+        (actual-ctx context))
+    (when (and (stringp actual-presets)
+               (or (file-directory-p actual-presets)
+                   (string-prefix-p "/" actual-presets)
+                   (string-suffix-p "/" actual-presets)))
+      (unless actual-dir
+        (setq actual-dir actual-presets))
+      (if (and (listp actual-ctx) (not (and (fboundp 'macher-context-p) (macher-context-p actual-ctx))))
+          (progn
+            (setq actual-presets actual-ctx)
+            (setq actual-ctx nil))
+        (setq actual-presets nil)))
+
+    (when (and (fboundp 'macher-context-p) (macher-context-p actual-presets))
+      (setq actual-ctx actual-presets)
+      (setq actual-presets nil))
+
+    (when (and (fboundp 'macher-context-p) (macher-context-p actual-dir))
+      (setq actual-ctx actual-dir)
+      (setq actual-dir (if (and (stringp presets) (not (equal presets actual-ctx))) presets nil)))
+
+    (when (and (fboundp 'macher-context-p) (macher-context-p actual-parent))
+      (setq actual-ctx actual-parent)
+      (setq actual-parent nil))
+
+    (unless actual-parent
+      (setq actual-parent (current-buffer)))
+
+    (let* ((resolved-ctx (or actual-ctx
+                             (when (buffer-live-p actual-parent)
+                               (with-current-buffer actual-parent
+                                 (bound-and-true-p macher-agent--persistent-context)))
+                             (ignore-errors (macher-agent-resolve-context actual-dir))))
+           (cloned-ctx (when resolved-ctx
+                         (if (fboundp 'macher-agent--clone-context)
+                             (macher-agent--clone-context resolved-ctx)
+                           resolved-ctx)))
+           (target-dir (or actual-dir
+                           (when cloned-ctx (ignore-errors (macher-agent-context-root cloned-ctx)))
+                           default-directory))
+           (buf (get-buffer-create name)))
+
+      (with-current-buffer buf
+        (when (and (fboundp 'markdown-mode) (not (derived-mode-p 'markdown-mode)))
+          (markdown-mode))
+        (when (and (fboundp 'gptel-mode) (not gptel-mode))
+          (gptel-mode 1))
+
+        (setq-local macher-agent--is-subagent t)
+        (setq-local macher-agent--is-workspace t)
+        (setq-local gptel-stream nil)
+        (setq-local macher-agent--parent-buffer actual-parent)
+        (setq-local default-directory (file-name-as-directory target-dir))
+
+        (when (buffer-live-p actual-parent)
+          (setq-local gptel-model (buffer-local-value 'gptel-model actual-parent))
+          (setq-local gptel-backend (buffer-local-value 'gptel-backend actual-parent))
+          (setq-local gptel-temperature (buffer-local-value 'gptel-temperature actual-parent))
+          (setq-local gptel-max-tokens (buffer-local-value 'gptel-max-tokens actual-parent)))
+
+        (when cloned-ctx
+          (setq-local macher-agent--persistent-context cloned-ctx))
+
+        (when actual-presets
+          (let ((preset-list (cond ((listp actual-presets) actual-presets)
+                                   ((vectorp actual-presets) (append actual-presets nil))
+                                   (t (list actual-presets)))))
+            (setq-local macher-agent-presets preset-list)
+            (macher-agent--apply-preset preset-list)))
+
+        (add-hook 'gptel-prompt-transform-functions #'macher-agent-sync-prompt-transformer nil t)
+        (add-hook 'gptel-pre-tool-call-functions #'macher-agent--enforce-tool-scope nil t)
+        (add-hook 'gptel-post-response-functions #'macher-agent-post-response-reaper nil t))
+
+      (when (boundp 'macher-agent-active-subagents)
+        (setq macher-agent-active-subagents
+              (cons (cons name target-dir)
+                    (cl-delete name macher-agent-active-subagents :key #'car :test #'equal))))
+
+      (when-let* ((ws (when cloned-ctx (ignore-errors (macher-agent--get-context-workspace cloned-ctx)))))
+        (let ((subs (ignore-errors (macher-agent-workspace-active-subagents ws))))
+          (macher-agent--set-workspace-active-subagents
+           ws
+           (cons (cons name target-dir)
+                 (cl-delete name subs :key #'car :test #'equal)))))
+
+      buf)))
+
+(defun macher-agent--prepare-subagent-instructions (subagent-buf instructions &optional presets)
+  "Prepare instruction text and system message payload locally in SUBAGENT-BUF.
+
+SUBAGENT-BUF is the target sub-agent buffer object or buffer name.
+INSTRUCTIONS is the directive string to insert into the sub-agent buffer.
+PRESETS is optional skill preset or list of presets to apply.
+
+Return SUBAGENT-BUF.
+
+Side effects: Applies presets, sets buffer text, and registers hooks in SUBAGENT-BUF."
+  (when-let* ((buf (if (bufferp subagent-buf)
+                       subagent-buf
+                     (get-buffer subagent-buf))))
+    (with-current-buffer buf
+      (when presets
+        (let ((preset-list (cond ((listp presets) presets)
+                                 ((vectorp presets) (append presets nil))
+                                 (t (list presets)))))
+          (setq-local macher-agent-presets preset-list)
+          (macher-agent--apply-preset preset-list)))
+      (add-hook 'gptel-prompt-transform-functions #'macher-agent-sync-prompt-transformer nil t)
+      (add-hook 'gptel-pre-tool-call-functions #'macher-agent--enforce-tool-scope nil t)
+      (when (and (stringp instructions) (not (string-empty-p instructions)))
+        (erase-buffer)
+        (insert instructions)))
+    buf))
+
 (defun macher-agent-spawn-task (task callback)
   "Spawn TASK inside a target sub-agent buffer.
 
@@ -546,18 +751,19 @@ CALLBACK is the completion callback function.
 Return nil.
 
 Side effects: Transmits task context to gptel and triggers CALLBACK on result."
-  (let* ((parent-buf (current-buffer))
-         (buf-name (if (listp task) (plist-get task :buffer_name) task))
-         (instructions (if (listp task) (plist-get task :instructions) ""))
-         (presets (if (listp task) (or (plist-get task :presets) (plist-get task :preset)) nil))
-         (is-background (and (listp task) (plist-get task :background)))
-         (suppress-patch (and (listp task) (plist-get task :suppress_patch)))
-         (buf (get-buffer buf-name)))
-    (if (not buf)
-        (funcall callback (make-macher-agent-delegate-response :status 'error :error (format "ERROR: Sub-agent buffer '%s' not found." buf-name) :buffer-name buf-name))
-      (let* ((parent-active-presets (with-current-buffer parent-buf (bound-and-true-p macher-agent-presets)))
-             (target-active-presets (with-current-buffer buf (bound-and-true-p macher-agent-presets)))
-             (resolved-presets (or presets target-active-presets parent-active-presets '("macher-agent-worker"))))
+  (if-let* ((buf-name (if (listp task) (plist-get task :buffer_name) task))
+            (buf (get-buffer buf-name)))
+      (let* ((parent-buf (current-buffer))
+             (instructions (if (listp task) (plist-get task :instructions) ""))
+             (presets
+              (if (listp task) (or (plist-get task :presets) (plist-get task :preset)) nil))
+             (is-background (and (listp task) (plist-get task :background)))
+             (suppress-patch (and (listp task) (plist-get task :suppress_patch)))
+             (parent-active-presets
+              (with-current-buffer parent-buf (bound-and-true-p macher-agent-presets)))
+             (target-active-presets
+              (with-current-buffer buf (bound-and-true-p macher-agent-presets)))
+             (resolved-presets (or presets target-active-presets)))
         (macher-agent--prepare-subagent-instructions buf instructions resolved-presets)
         (with-current-buffer buf
           (unless is-background
@@ -567,294 +773,79 @@ Side effects: Transmits task context to gptel and triggers CALLBACK on result."
           (setq-local macher-agent--parent-buffer parent-buf)
           (setq-local macher-agent--suppress-patch suppress-patch)
 
+          (add-hook
+           'gptel-prompt-transform-functions #'macher-agent-sync-prompt-transformer nil t)
+          (add-hook 'gptel-pre-tool-call-functions #'macher-agent--enforce-tool-scope nil t)
+
           (setq-local macher-agent--parent-callback
-                      (macher-agent--make-subagent-parent-callback buf parent-buf is-background callback))
+                      (macher-agent--make-subagent-parent-callback
+                       buf parent-buf is-background callback))
 
           (let* ((clean-sym (macher-agent--extract-first-preset-symbol resolved-presets))
                  (task-ctx (make-macher-agent-task-context
                             :workspace nil
                             :target-buffer buf
                             :skill-sym clean-sym
-                            :system-message gptel-system-prompt)))
+                            :system-message (bound-and-true-p gptel-system-prompt))))
 
             (macher-agent-gptel-transmit
              task-ctx
-             (list :on-success (lambda (res)
-                                 (funcall macher-agent--parent-callback (make-macher-agent-delegate-response :status 'success :data res :buffer-name buf-name)))
-                   :on-error (lambda (err)
-                               (funcall macher-agent--parent-callback (make-macher-agent-delegate-response :status 'error :error (format "ERROR: %s" err) :buffer-name buf-name)))))))))))
-
-(defvar macher-agent-subagent-setup-hook nil
-  "Hook run after preparing a sub-agent buffer.
-
-Runs during sub-agent initialisation after default directory, mode, and gptel
-settings have been applied.
-
-Return value of hook when executed.
-
-Side effects: Runs registered hook functions.")
-
-(defun macher-agent--add-buffer-to-scope-headless (buf-name persistent-context)
-  "Add BUF-NAME to PERSISTENT-CONTEXT scope headlessly.
-
-BUF-NAME is the string buffer name.
-PERSISTENT-CONTEXT is the active context structure.
-
-Return nil.
-
-Side effects: Mutates PERSISTENT-CONTEXT and runs `macher-agent-context-mutated-hook'."
-  (get-buffer-create buf-name)
-  (when persistent-context
-    (let* ((contents (macher-agent--get-context-contents persistent-context))
-           (entry (cl-find buf-name contents :key #'car :test #'equal)))
-      (unless entry
-        (let ((orig (with-current-buffer buf-name (buffer-substring-no-properties (point-min) (point-max)))))
-          (macher-agent--set-context-contents persistent-context
-                                              (cons (cons buf-name (cons orig orig)) contents))))))
-  (run-hooks 'macher-agent-context-mutated-hook))
-
-;;;###autoload
-(defun macher-agent-add-buffer-to-scope (buffer)
-  "Add BUFFER to the scope of the current agent.
-
-BUFFER is the buffer object or string name.
-
-Return nil.
-
-Side effects: Mutates active context and displays message."
-  (interactive "BAdd buffer to current agent's scope: ")
-  (let ((buf-name (if (stringp buffer) buffer (buffer-name buffer)))
-        (ctx (macher-agent-resolve-context)))
-    (if (not ctx)
-        (error "No active agent session found")
-      (macher-agent--add-buffer-to-scope-headless buf-name ctx)
-      (message "SUCCESS: Added '%s' to the agent's restricted scope." buf-name))))
-
-(defun macher-agent--resolve-buffer-name (name)
-  "Coerce NAME into a string buffer name.
-
-NAME is the string representing buffer name.
-
-Return the coerced buffer name string.
-
-Side effects: None."
-  (substring-no-properties name))
-
-(defun macher-agent--prepare-subagent-buffer (buf full-dir context &optional presets parent-tools parent-model parent-backend parent-presets parent-directives parent-temp parent-tokens)
-  "Prepare sub-agent BUF with locked directory and composed skills.
-
-BUF is the target buffer.
-FULL-DIR is the path to lock.
-CONTEXT is the active context structure.
-PRESETS represents the requested presets.
-PARENT-TOOLS is the parent's tools list.
-PARENT-MODEL is the parent's model.
-PARENT-BACKEND is the parent's backend.
-PARENT-PRESETS represents the parent's known presets.
-PARENT-DIRECTIVES represents the parent's directives.
-PARENT-TEMP is the parent's temperature.
-PARENT-TOKENS is the parent's max tokens.
-
-Return nil.
-
-Side effects: Configures buffer-local variables, mode, and hooks in BUF."
-  (with-current-buffer buf
-    (setq default-directory (file-name-as-directory (macher-agent-root full-dir)))
-
-    (when (and (fboundp 'markdown-mode) (not (derived-mode-p 'markdown-mode)))
-      (markdown-mode))
-
-    (setq-local macher-agent--is-subagent t)
-    (setq-local macher-agent--is-workspace t)
-
-    (when (and (fboundp 'gptel-mode) (not gptel-mode))
-      (gptel-mode 1))
-
-    (setq-local gptel-stream nil)
-
-    (when context
-      (setq-local macher--workspace (macher-agent--get-context-workspace context))
-      (macher-agent--inject-context-state context))
-
-    (when parent-model (setq-local gptel-model parent-model))
-    (when parent-backend (setq-local gptel-backend parent-backend))
-    (when parent-presets (setq-local gptel--known-presets parent-presets))
-    (when parent-directives (setq-local gptel-directives parent-directives))
-    (when parent-temp (setq-local gptel-temperature parent-temp))
-    (when parent-tokens (setq-local gptel-max-tokens parent-tokens))
-
-    (unless (boundp 'gptel-tools) (setq gptel-tools nil))
-    (make-local-variable 'gptel-tools)
-
-    (when parent-tools
-      (setq gptel-tools (macher-agent-normalize-tools (append gptel-tools parent-tools))))
-
-    (when presets
-      (let* ((preset-list (if (listp presets) presets (list presets)))
-             (base-state (list :model gptel-model
-                               :system nil
-                               :temperature (bound-and-true-p gptel-temperature)
-                               :max-tokens (bound-and-true-p gptel-max-tokens)
-                               :tools gptel-tools
-                               :known-presets (bound-and-true-p gptel--known-presets)))
-             (payload (macher-agent-compose-payload base-state preset-list)))
-        (setq-local macher-agent-presets (delete-dups (append macher-agent-presets preset-list)))
-        (macher-agent--apply-payload-locally payload)))
-
-    (add-hook 'gptel-prompt-transform-functions #'macher-agent-sync-prompt-transformer nil t)
-    (add-hook 'gptel-post-response-functions #'macher-agent-post-response-reaper nil t)
-
-    (run-hooks 'macher-agent-subagent-setup-hook)))
-
-(defun macher-agent-add-subagent (name dir &optional instructions context presets)
-  "Create a new sub-agent buffer inheriting parent state.
-
-NAME is the sub-agent name string.
-DIR is the workspace directory path string.
-INSTRUCTIONS is the optional instructions string.
-CONTEXT is the optional active context structure.
-PRESETS represents optional requested presets.
-
-Return the newly created sub-agent buffer.
-
-Side effects: Creates buffer and updates workspace active sub-agents."
-  (when context
-    (macher-agent-initialize-skills context))
-  (let* ((parent-buf (current-buffer))
-         (parent-tools (bound-and-true-p gptel-tools))
-         (parent-model (bound-and-true-p gptel-model))
-         (parent-backend (bound-and-true-p gptel-backend))
-         (parent-presets (bound-and-true-p gptel--known-presets))
-         (parent-directives (bound-and-true-p gptel-directives))
-         (parent-temp (bound-and-true-p gptel-temperature))
-         (parent-tokens (bound-and-true-p gptel-max-tokens))
-         (parent-active-presets (bound-and-true-p macher-agent-presets))
-         (resolved-presets (or presets parent-active-presets '("macher-agent-worker")))
-         (resolved-ctx (or context
-                           (with-current-buffer parent-buf
-                             (bound-and-true-p macher-agent--persistent-context))
-                           (ignore-errors (macher-agent-resolve-context))))
-         (child-ctx (when resolved-ctx (macher-agent--clone-context resolved-ctx)))
-         (buf (get-buffer-create name)))
-
-    (macher-agent--prepare-subagent-buffer
-     buf dir child-ctx resolved-presets parent-tools parent-model parent-backend
-     parent-presets parent-directives parent-temp parent-tokens)
-
-    (when (and instructions (not (string-empty-p instructions)))
-      (macher-agent--prepare-subagent-instructions buf instructions resolved-presets))
-
-    (with-current-buffer buf
-      (setq-local macher-agent--parent-buffer parent-buf))
-
-    (when resolved-ctx
-      (let ((workspace (macher-agent--get-context-workspace resolved-ctx)))
-        (when workspace
-          (push (cons name buf) (macher-agent-workspace-active-subagents workspace))))
-      (macher-agent-scope-add-file name resolved-ctx))
-    buf))
-
-(defun macher-agent--prepare-subagent-instructions (buf instructions &optional presets)
-  "Insert INSTRUCTIONS into BUF and compose its system message.
-
-BUF is the target buffer.
-INSTRUCTIONS is the instructions string.
-PRESETS represents the optional requested presets.
-
-Return nil.
-
-Side effects: Modifies buffer content and buffer-local variables in BUF."
-  (with-current-buffer buf
-    (unless (string-empty-p instructions)
-      (insert (substring-no-properties instructions)))
-    (when presets
-      (let* ((preset-list (if (listp presets) presets (list presets)))
-             (base-state (list :model gptel-model
-                               :system nil
-                               :temperature (bound-and-true-p gptel-temperature)
-                               :max-tokens (bound-and-true-p gptel-max-tokens)
-                               :tools gptel-tools
-                               :known-presets (bound-and-true-p gptel--known-presets)))
-             (payload (macher-agent-compose-payload base-state preset-list)))
-        (setq-local macher-agent-presets (delete-dups (append macher-agent-presets preset-list)))
-        (macher-agent--apply-payload-locally payload)))))
+             (list
+              :on-success
+              (lambda (res)
+                (funcall
+                 macher-agent--parent-callback
+                 (make-macher-agent-delegate-response
+                  :status 'success :data res :buffer-name buf-name)))
+              :on-error
+              (lambda (err)
+                (funcall
+                 macher-agent--parent-callback
+                 (make-macher-agent-delegate-response
+                  :status 'error :error (format "ERROR: %s" err) :buffer-name buf-name))))))))
+    (let
+        ((buf-name (if (listp task) (plist-get task :buffer_name) task)))
+      (funcall
+       callback
+       (make-macher-agent-delegate-response
+        :status 'error
+        :error
+        (format "ERROR: Sub-agent buffer '%s' not found." buf-name) :buffer-name buf-name)))))
 
 (defun macher-agent--apply-single-virtual-buffer (entry)
-  "Apply new content from VFS ENTRY to its buffer if present.
+  "Apply a single VFS virtual edit ENTRY to a live Emacs buffer.
 
-ENTRY is a VFS context entry cons cell.
+ENTRY is a VFS context entry structure or cell.
 
-Return nil.
+Return non-nil if applied to a live buffer, otherwise nil.
 
-Side effects: Erases and updates buffer text if target buffer exists."
-  (let* ((path-or-buf (car entry))
-         (new-content (if (consp (cdr entry)) (cddr entry) (cdr entry))))
-    (when (and new-content (get-buffer path-or-buf))
-      (with-current-buffer (get-buffer path-or-buf)
-        (erase-buffer)
-        (insert new-content)))))
+Side effects: Modifies the target live buffer contents."
+  (when entry
+    (let* ((path (ignore-errors (macher-agent-vfs-entry-path entry)))
+           (curr (ignore-errors (macher-agent-vfs-entry-curr entry)))
+           (buf-name (when path (macher-agent--resolve-buffer-name path)))
+           (buf (when buf-name (get-buffer buf-name))))
+      (when (and buf (buffer-live-p buf) (stringp curr))
+        (with-current-buffer buf
+          (erase-buffer)
+          (insert curr))
+        t))))
 
-(defun macher-agent-apply-virtual-buffers ()
-  "Apply uncommitted VFS memory content back to virtual buffers.
+(defun macher-agent-apply-virtual-buffers (&optional context)
+  "Apply pending VFS virtual edits to live Emacs buffers.
 
-Iterates over entries in active VFS context and writes uncommitted
-virtual content back into matching Emacs buffers.
-
-Return nil.
-
-Side effects: Updates buffer contents and auto-syncs context."
-  (interactive)
-  (when-let* ((ctx (macher-agent-resolve-context))
-              (contents (macher-agent--get-context-contents ctx)))
-    (mapc #'macher-agent--apply-single-virtual-buffer contents)
-    (macher-agent--auto-sync-context ctx)
-    (message "Virtual buffers applied successfully.")))
-
-(add-hook 'gptel-pre-response-hook
-          (lambda ()
-            (setq-local macher-agent--pending-children nil)
-            (setq-local macher-agent--child-results nil)
-            (setq-local macher-agent--resume-callback nil)
-            (when-let* ((ctx (ignore-errors (macher-agent-resolve-context))))
-              (macher-agent--auto-sync-context ctx))))
-
-(defun macher-agent--dispatch-resume-callback (parent-buf callback results)
-  "Schedule execution of CALLBACK on PARENT-BUF with RESULTS.
-
-PARENT-BUF is the parent orchestrator buffer.
-CALLBACK is the resume callback function.
-RESULTS is the list of child results.
+CONTEXT is the optional VFS context structure. If omitted, resolves
+the active context.
 
 Return nil.
 
-Side effects: Schedules a timer to execute CALLBACK."
-  (when callback
-    (run-at-time 0 nil
-                 (lambda ()
-                   (when (buffer-live-p parent-buf)
-                     (with-current-buffer parent-buf
-                       (funcall callback
-                                (make-macher-agent-delegate-response
-                                 :status 'success
-                                 :payload (vconcat results)
-                                 :buffer-name (buffer-name parent-buf)))))))))
-
-(defun macher-agent-resume-parent-agent ()
-  "Aggregate sub-agent results and resume the parent agent cycle.
-
-Collects child results from buffer-local state and dispatches the stored
-resume callback on a clean call stack.
-
-Return nil.
-
-Side effects: Resets child state variables and schedules resume callback."
-  (let ((parent-buf (current-buffer))
-        (callback macher-agent--resume-callback)
-        (results (copy-sequence macher-agent--child-results)))
-    (setq-local macher-agent--child-results nil)
-    (setq-local macher-agent--pending-children nil)
-    (setq-local macher-agent--resume-callback nil)
-    (macher-agent--dispatch-resume-callback parent-buf callback results)))
+Side effects: Modifies contents of live buffers matching VFS entries."
+  (let* ((ctx (or context (ignore-errors (macher-agent-resolve-context))))
+         (contents (when ctx (ignore-errors (macher-agent--get-context-contents ctx)))))
+    (dolist (entry contents)
+      (macher-agent--apply-single-virtual-buffer entry))
+    (when (fboundp 'macher-agent--auto-sync-context)
+      (macher-agent--auto-sync-context ctx))))
 
 (provide 'macher-agent-orchestration)
 ;;; macher-agent-orchestration.el ends here

--- a/macher-agent-sandbox.el
+++ b/macher-agent-sandbox.el
@@ -97,7 +97,7 @@ Side effects: Initialises and mutates buffer-local sandbox state variables."
       (puthash op op macher-agent-sandbox--primitives))))
 
 (iter-defun macher-agent-sandbox--eval-args-iter (args env)
-  "Evaluate a list of ARGS in ENV using the generator evaluator.
+            "Evaluate a list of ARGS in ENV using the generator evaluator.
 
 Evaluate each argument expression in ARGS sequentially using the
 sandboxed generator evaluator within environment ENV.
@@ -107,12 +107,12 @@ ENV is the current lexical environment alist.
 
 Return a list of evaluated argument values.
 Side effects: May mutate global sandbox state during evaluation."
-  (let ((evaled nil))
-    (dolist (arg args (nreverse evaled))
-      (push (iter-yield-from (macher-agent-sandbox--eval-iter arg env)) evaled))))
+            (let ((evaled nil))
+              (dolist (arg args (nreverse evaled))
+                (push (iter-yield-from (macher-agent-sandbox--eval-iter arg env)) evaled))))
 
 (iter-defun macher-agent-sandbox--apply-closure-iter (closure arguments)
-  "Execute CLOSURE with ARGUMENTS as a generator.
+            "Execute CLOSURE with ARGUMENTS as a generator.
 
 Bind CLOSURE parameters to evaluated ARGUMENTS in a new lexical environment
 and evaluate the CLOSURE body forms sequentially.
@@ -122,13 +122,13 @@ ARGUMENTS is a list of evaluated argument values to bind.
 
 Return the result of evaluating the final body form in CLOSURE.
 Side effects: May mutate global sandbox state during execution."
-  (let ((new-env (cadddr closure))
-        (params (cadr closure))
-        (result nil))
-    (while params
-      (push (cons (pop params) (pop arguments)) new-env))
-    (dolist (form (caddr closure) result)
-      (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form new-env))))))
+            (let ((new-env (cadddr closure))
+                  (params (cadr closure))
+                  (result nil))
+              (while params
+                (push (cons (pop params) (pop arguments)) new-env))
+              (dolist (form (caddr closure) result)
+                (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form new-env))))))
 
 (defun macher-agent-sandbox--normalize-args-to-plist (args)
   "Normalise ARGS into a standard plist for tool calls.
@@ -175,7 +175,7 @@ Side effects: None."
    (t args)))
 
 (iter-defun macher-agent-sandbox--funcall-symbol-iter (func eval-args)
-  "Execute function symbol FUNC with EVAL-ARGS in the sandbox.
+            "Execute function symbol FUNC with EVAL-ARGS in the sandbox.
 
 Look up function symbol FUNC in PTC primitives, allowed primitive
 table, or defined guest closures, and execute or yield as appropriate.
@@ -185,24 +185,24 @@ EVAL-ARGS is the list of evaluated argument values.
 
 Return the result of the function call or yield a tool call interrupt.
 Side effects: May yield an interrupt or mutate global sandbox state."
-  (let ((prim (and macher-agent-sandbox--primitives (gethash func macher-agent-sandbox--primitives)))
-        (closure (and macher-agent-sandbox--functions (gethash func macher-agent-sandbox--functions))))
+            (let ((prim (and macher-agent-sandbox--primitives (gethash func macher-agent-sandbox--primitives)))
+                  (closure (and macher-agent-sandbox--functions (gethash func macher-agent-sandbox--functions))))
 
-    (cond
-     ((and (fboundp 'macher-agent--ptc-primitive-p)
-           (macher-agent--ptc-primitive-p func))
-      (iter-yield (list :interrupt 'tool-call
-                        :name func
-                        :args (macher-agent-sandbox--normalize-args-to-plist eval-args))))
-     (prim
-      (apply prim eval-args))
-     (closure
-      (iter-yield-from (macher-agent-sandbox--apply-closure-iter closure eval-args)))
-     (t
-      (error "Void or forbidden function: %s" func)))))
+              (cond
+               ((and (fboundp 'macher-agent--ptc-primitive-p)
+                     (macher-agent--ptc-primitive-p func))
+                (iter-yield (list :interrupt 'tool-call
+                                  :name func
+                                  :args (macher-agent-sandbox--normalize-args-to-plist eval-args))))
+               (prim
+                (apply prim eval-args))
+               (closure
+                (iter-yield-from (macher-agent-sandbox--apply-closure-iter closure eval-args)))
+               (t
+                (error "Void or forbidden function: %s" func)))))
 
 (iter-defun macher-agent-sandbox--funcall-iter (func eval-args)
-  "Execute function FUNC with EVAL-ARGS in the sandbox.
+            "Execute function FUNC with EVAL-ARGS in the sandbox.
 
 Dispatch execution of FUNC based on whether it is a closure structure
 or a function symbol.
@@ -212,17 +212,17 @@ EVAL-ARGS is the list of evaluated argument values.
 
 Return the result of invoking FUNC with EVAL-ARGS.
 Side effects: May yield an interrupt or mutate global sandbox state."
-  ;;(message func)
-  (cond
-   ((and (consp func) (eq (car func) 'closure))
-    (iter-yield-from (macher-agent-sandbox--apply-closure-iter func eval-args)))
-   ((symbolp func)
-    (iter-yield-from (macher-agent-sandbox--funcall-symbol-iter func eval-args)))
-   (t
-    (error "Invalid function target: %s" func))))
+            ;;(message func)
+            (cond
+             ((and (consp func) (eq (car func) 'closure))
+              (iter-yield-from (macher-agent-sandbox--apply-closure-iter func eval-args)))
+             ((symbolp func)
+              (iter-yield-from (macher-agent-sandbox--funcall-symbol-iter func eval-args)))
+             (t
+              (error "Invalid function target: %s" func))))
 
 (iter-defun macher-agent-sandbox--eval-single-binding-iter (binding eval-env)
-  "Evaluate a single BINDING specification in EVAL-ENV.
+            "Evaluate a single BINDING specification in EVAL-ENV.
 
 Evaluate the value expression of BINDING within environment EVAL-ENV
 and construct a variable-value pair cons cell.
@@ -232,14 +232,14 @@ EVAL-ENV is the lexical environment alist used to evaluate VAL.
 
 Return a (VAR . VAL) cons cell.
 Side effects: May mutate global sandbox state during evaluation."
-  (let ((var (if (consp binding) (car binding) binding))
-        (val (when (consp binding)
-               (iter-yield-from
-                (macher-agent-sandbox--eval-iter (cadr binding) eval-env)))))
-    (cons var val)))
+            (let ((var (if (consp binding) (car binding) binding))
+                  (val (when (consp binding)
+                         (iter-yield-from
+                          (macher-agent-sandbox--eval-iter (cadr binding) eval-env)))))
+              (cons var val)))
 
 (iter-defun macher-agent-sandbox--bind-iter (bindings env is-star)
-  "Process BINDINGS to extend lexical environment ENV.
+            "Process BINDINGS to extend lexical environment ENV.
 
 Evaluate each binding in BINDINGS and extend ENV, supporting sequential
 lexical binding if IS-STAR is non-nil.
@@ -250,15 +250,15 @@ IS-STAR is non-nil for sequential let* binding, or nil for parallel let binding.
 
 Return the extended lexical environment alist.
 Side effects: May mutate global sandbox state during binding evaluation."
-  (let ((new-env env))
-    (dolist (binding bindings new-env)
-      (let* ((eval-env (if is-star new-env env))
-             (pair (iter-yield-from
-                    (macher-agent-sandbox--eval-single-binding-iter binding eval-env))))
-        (setq new-env (cons pair new-env))))))
+            (let ((new-env env))
+              (dolist (binding bindings new-env)
+                (let* ((eval-env (if is-star new-env env))
+                       (pair (iter-yield-from
+                              (macher-agent-sandbox--eval-single-binding-iter binding eval-env))))
+                  (setq new-env (cons pair new-env))))))
 
 (iter-defun macher-agent-sandbox--eval-and-or-iter (args env is-or)
-  "Evaluate boolean logic forms ARGS in ENV.
+            "Evaluate boolean logic forms ARGS in ENV.
 
 Evaluate expressions in ARGS sequentially in environment ENV with short-circuit
 logic, implementing logical OR if IS-OR is non-nil, or logical AND otherwise.
@@ -269,13 +269,13 @@ IS-OR is non-nil for or forms, or nil for and forms.
 
 Return the result of short-circuit evaluation.
 Side effects: May mutate global sandbox state during evaluation."
-  (let ((result (not is-or)))
-    (while (and args (if is-or (not result) result))
-      (setq result (iter-yield-from (macher-agent-sandbox--eval-iter (pop args) env))))
-    result))
+            (let ((result (not is-or)))
+              (while (and args (if is-or (not result) result))
+                (setq result (iter-yield-from (macher-agent-sandbox--eval-iter (pop args) env))))
+              result))
 
 (iter-defun macher-agent-sandbox--eval-let-iter (args env is-star)
-  "Evaluate let or let* form ARGS in ENV.
+            "Evaluate let or let* form ARGS in ENV.
 
 Bind variables in (car ARGS) using environment ENV and evaluate body
 expressions in (cdr ARGS) sequentially.
@@ -286,13 +286,13 @@ IS-STAR is non-nil for let* binding, or nil for standard let binding.
 
 Return the value of the final body form.
 Side effects: May mutate global sandbox state during evaluation."
-  (let ((new-env (iter-yield-from (macher-agent-sandbox--bind-iter (car args) env is-star)))
-        (result nil))
-    (dolist (form (cdr args) result)
-      (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form new-env))))))
+            (let ((new-env (iter-yield-from (macher-agent-sandbox--bind-iter (car args) env is-star)))
+                  (result nil))
+              (dolist (form (cdr args) result)
+                (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form new-env))))))
 
 (iter-defun macher-agent-sandbox--eval-setq-iter (args env)
-  "Evaluate setq form ARGS in ENV.
+            "Evaluate setq form ARGS in ENV.
 
 Assign values to variable symbols pair by pair in ARGS, updating lexical
 binding in ENV if present, or setting global sandbox variable otherwise.
@@ -302,20 +302,20 @@ ENV is the current lexical environment alist.
 
 Return the value assigned to the final variable.
 Side effects: Mutates variable bindings in ENV or `macher-agent-sandbox--globals`."
-  (let ((val nil))
-    (while args
-      (let* ((var (pop args))
-             (rhs (pop args))
-             (evaled (iter-yield-from (macher-agent-sandbox--eval-iter rhs env)))
-             (binding (assoc var env)))
-        (setq val evaled)
-        (if binding
-            (setcdr binding val)
-          (puthash var val macher-agent-sandbox--globals))))
-    val))
+            (let ((val nil))
+              (while args
+                (let* ((var (pop args))
+                       (rhs (pop args))
+                       (evaled (iter-yield-from (macher-agent-sandbox--eval-iter rhs env)))
+                       (binding (assoc var env)))
+                  (setq val evaled)
+                  (if binding
+                      (setcdr binding val)
+                    (puthash var val macher-agent-sandbox--globals))))
+              val))
 
 (iter-defun macher-agent-sandbox--eval-mapcar-iter (args env)
-  "Evaluate mapcar form ARGS in ENV.
+            "Evaluate mapcar form ARGS in ENV.
 
 Evaluate function and sequence expressions in ARGS within environment ENV,
 then map the function over sequence items sequentially.
@@ -325,16 +325,16 @@ ENV is the current lexical environment alist.
 
 Return a list of mapped elements.
 Side effects: May yield tool call interrupts or mutate global sandbox state."
-  (let ((func (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
-        (seq (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env)))
-        (result nil))
-    (unless (listp seq)
-      (error "Execution error (mapcar): Wrong type argument: listp, %s" seq))
-    (dolist (item seq (nreverse result))
-      (push (iter-yield-from (macher-agent-sandbox--funcall-iter func (list item))) result))))
+            (let ((func (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
+                  (seq (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env)))
+                  (result nil))
+              (unless (listp seq)
+                (error "Execution error (mapcar): Wrong type argument: listp, %s" seq))
+              (dolist (item seq (nreverse result))
+                (push (iter-yield-from (macher-agent-sandbox--funcall-iter func (list item))) result))))
 
 (iter-defun macher-agent-sandbox--eval-mapc-iter (args env)
-  "Evaluate mapc form ARGS in ENV.
+            "Evaluate mapc form ARGS in ENV.
 
 Evaluate function and sequence expressions in ARGS within environment ENV,
 then apply the function to sequence items sequentially.
@@ -344,138 +344,138 @@ ENV is the current lexical environment alist.
 
 Return the sequence argument SEQ.
 Side effects: May yield tool call interrupts or mutate global sandbox state."
-  (let ((func (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
-        (seq (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env))))
-    (unless (listp seq)
-      (error "Execution error (mapc): Wrong type argument: listp, %s" seq))
-    (dolist (item seq seq)
-      (iter-yield-from (macher-agent-sandbox--funcall-iter func (list item))))))
+            (let ((func (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
+                  (seq (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env))))
+              (unless (listp seq)
+                (error "Execution error (mapc): Wrong type argument: listp, %s" seq))
+              (dolist (item seq seq)
+                (iter-yield-from (macher-agent-sandbox--funcall-iter func (list item))))))
 
 (defvar-local macher-agent-sandbox--special-forms
   `((quote . ,(iter-lambda (args _env) (car args)))
     (mapcar . ,(iter-lambda (args env) (iter-yield-from (macher-agent-sandbox--eval-mapcar-iter args env))))
     (mapc . ,(iter-lambda (args env) (iter-yield-from (macher-agent-sandbox--eval-mapc-iter args env))))
     (function . ,(iter-lambda (args env)
-                   (let ((fn-target (car args)))
-                     (if (symbolp fn-target)
-                         fn-target
-                       (iter-yield-from (macher-agent-sandbox--eval-iter fn-target env))))))
+                              (let ((fn-target (car args)))
+                                (if (symbolp fn-target)
+                                    fn-target
+                                  (iter-yield-from (macher-agent-sandbox--eval-iter fn-target env))))))
     (lambda . ,(iter-lambda (args env)
-                 (list 'closure (car args) (cdr args) env)))
+                            (list 'closure (car args) (cdr args) env)))
     (progn . ,(iter-lambda (args env)
-                (let ((result nil))
-                  (dolist (form args result)
-                    (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form env)))))))
+                           (let ((result nil))
+                             (dolist (form args result)
+                               (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form env)))))))
     (if . ,(iter-lambda (args env)
-             (if (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))
-                 (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env))
-               (iter-yield-from (macher-agent-sandbox--eval-iter (caddr args) env)))))
+                        (if (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))
+                            (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env))
+                          (iter-yield-from (macher-agent-sandbox--eval-iter (caddr args) env)))))
     (and . ,(iter-lambda (args env)
-              (iter-yield-from (macher-agent-sandbox--eval-and-or-iter args env nil))))
+                         (iter-yield-from (macher-agent-sandbox--eval-and-or-iter args env nil))))
     (or . ,(iter-lambda (args env)
-             (iter-yield-from (macher-agent-sandbox--eval-and-or-iter args env t))))
+                        (iter-yield-from (macher-agent-sandbox--eval-and-or-iter args env t))))
     (cond . ,(iter-lambda (args env)
-               (let ((result nil)
-                     (matched nil))
-                 (while (and args (not matched))
-                   (let* ((clause (pop args))
-                          (cond-val (iter-yield-from (macher-agent-sandbox--eval-iter (car clause) env))))
-                     (when cond-val
-                       (setq matched t)
-                       (if (cdr clause)
-                           (dolist (form (cdr clause))
-                             (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form env))))
-                         (setq result cond-val)))))
-                 result)))
+                          (let ((result nil)
+                                (matched nil))
+                            (while (and args (not matched))
+                              (let* ((clause (pop args))
+                                     (cond-val (iter-yield-from (macher-agent-sandbox--eval-iter (car clause) env))))
+                                (when cond-val
+                                  (setq matched t)
+                                  (if (cdr clause)
+                                      (dolist (form (cdr clause))
+                                        (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form env))))
+                                    (setq result cond-val)))))
+                            result)))
     (setq . ,(iter-lambda (args env)
-               (iter-yield-from (macher-agent-sandbox--eval-setq-iter args env))))
+                          (iter-yield-from (macher-agent-sandbox--eval-setq-iter args env))))
     (while . ,(iter-lambda (args env)
-                (while (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))
-                  (dolist (form (cdr args))
-                    (iter-yield-from (macher-agent-sandbox--eval-iter form env))))
-                nil))
+                           (while (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))
+                             (dolist (form (cdr args))
+                               (iter-yield-from (macher-agent-sandbox--eval-iter form env))))
+                           nil))
     (let . ,(iter-lambda (args env)
-              (iter-yield-from (macher-agent-sandbox--eval-let-iter args env nil))))
+                         (iter-yield-from (macher-agent-sandbox--eval-let-iter args env nil))))
     (let* . ,(iter-lambda (args env)
-               (iter-yield-from (macher-agent-sandbox--eval-let-iter args env t))))
+                          (iter-yield-from (macher-agent-sandbox--eval-let-iter args env t))))
     (defalias . ,(iter-lambda (args env)
-                   (let ((func-name (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
-                         (func-body (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env))))
-                     (puthash func-name func-body macher-agent-sandbox--functions)
-                     func-name)))
+                              (let ((func-name (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
+                                    (func-body (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env))))
+                                (puthash func-name func-body macher-agent-sandbox--functions)
+                                func-name)))
     (funcall . ,(iter-lambda (args env)
-                  (let ((func (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
-                        (eval-args (iter-yield-from (macher-agent-sandbox--eval-args-iter (cdr args) env))))
-                    (iter-yield-from (macher-agent-sandbox--funcall-iter func eval-args)))))
+                             (let ((func (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
+                                   (eval-args (iter-yield-from (macher-agent-sandbox--eval-args-iter (cdr args) env))))
+                               (iter-yield-from (macher-agent-sandbox--funcall-iter func eval-args)))))
     (apply . ,(iter-lambda (args env)
-                (let* ((func (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
-                       (eval-args (iter-yield-from (macher-agent-sandbox--eval-args-iter (cdr args) env)))
-                       (final-args (append (butlast eval-args) (car (last eval-args)))))
-                  (iter-yield-from (macher-agent-sandbox--funcall-iter func final-args)))))
+                           (let* ((func (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
+                                  (eval-args (iter-yield-from (macher-agent-sandbox--eval-args-iter (cdr args) env)))
+                                  (final-args (append (butlast eval-args) (car (last eval-args)))))
+                             (iter-yield-from (macher-agent-sandbox--funcall-iter func final-args)))))
     (condition-case . ,(iter-lambda (args env)
-                         (let ((var (car args))
-                               (bodyform (cadr args))
-                               (handlers (cddr args)))
-                           (condition-case err
-                               (iter-yield-from (macher-agent-sandbox--eval-iter bodyform env))
-                             (error
-                              (let* ((err-sym (car err))
-                                     (matched-handler nil))
-                                (dolist (handler handlers)
-                                  (let ((cond-spec (car handler)))
-                                    (when (or (eq cond-spec t)
-                                              (eq cond-spec err-sym)
-                                              (and (listp cond-spec) (memq err-sym cond-spec)))
-                                      (setq matched-handler handler))))
-                                (if matched-handler
-                                    (let ((new-env (if var (cons (cons var err) env) env))
-                                          (result nil))
-                                      (dolist (form (cdr matched-handler) result)
-                                        (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form new-env)))))
-                                  (signal (car err) (cdr err)))))))))
+                                    (let ((var (car args))
+                                          (bodyform (cadr args))
+                                          (handlers (cddr args)))
+                                      (condition-case err
+                                          (iter-yield-from (macher-agent-sandbox--eval-iter bodyform env))
+                                        (error
+                                         (let* ((err-sym (car err))
+                                                (matched-handler nil))
+                                           (dolist (handler handlers)
+                                             (let ((cond-spec (car handler)))
+                                               (when (or (eq cond-spec t)
+                                                         (eq cond-spec err-sym)
+                                                         (and (listp cond-spec) (memq err-sym cond-spec)))
+                                                 (setq matched-handler handler))))
+                                           (if matched-handler
+                                               (let ((new-env (if var (cons (cons var err) env) env))
+                                                     (result nil))
+                                                 (dolist (form (cdr matched-handler) result)
+                                                   (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form new-env)))))
+                                             (signal (car err) (cdr err)))))))))
     (unwind-protect . ,(iter-lambda (args env)
-                         (unwind-protect
-                             (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))
-                           (dolist (form (cdr args))
-                             (iter-yield-from (macher-agent-sandbox--eval-iter form env))))))
+                                    (unwind-protect
+                                        (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))
+                                      (dolist (form (cdr args))
+                                        (iter-yield-from (macher-agent-sandbox--eval-iter form env))))))
     (catch . ,(iter-lambda (args env)
-                (catch (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))
-                  (let ((result nil))
-                    (dolist (form (cdr args) result)
-                      (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form env))))))))
+                           (catch (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))
+                             (let ((result nil))
+                               (dolist (form (cdr args) result)
+                                 (setq result (iter-yield-from (macher-agent-sandbox--eval-iter form env))))))))
     (throw . ,(iter-lambda (args env)
-                (throw (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))
-                       (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env)))))
+                           (throw (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))
+                                  (iter-yield-from (macher-agent-sandbox--eval-iter (cadr args) env)))))
     (fboundp . ,(iter-lambda (args env)
-                  (let ((sym (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))))
-                    (when (symbolp sym)
-                      (or (gethash sym macher-agent-sandbox--primitives)
-                          (gethash sym macher-agent-sandbox--functions)
-                          (and (fboundp 'macher-agent--ptc-primitive-p)
-                               (macher-agent--ptc-primitive-p sym))
-                          (assoc sym macher-agent-sandbox--special-forms))))))
+                             (let ((sym (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))))
+                               (when (symbolp sym)
+                                 (or (gethash sym macher-agent-sandbox--primitives)
+                                     (gethash sym macher-agent-sandbox--functions)
+                                     (and (fboundp 'macher-agent--ptc-primitive-p)
+                                          (macher-agent--ptc-primitive-p sym))
+                                     (assoc sym macher-agent-sandbox--special-forms))))))
     (boundp . ,(iter-lambda (args env)
-                 (let ((sym (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))))
-                   (when (symbolp sym)
-                     (or (assoc sym env)
-                         (not (eq (gethash sym macher-agent-sandbox--globals macher-agent-sandbox--unbound)
-                                  macher-agent-sandbox--unbound)))))))
+                            (let ((sym (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))))
+                              (when (symbolp sym)
+                                (or (assoc sym env)
+                                    (not (eq (gethash sym macher-agent-sandbox--globals macher-agent-sandbox--unbound)
+                                             macher-agent-sandbox--unbound)))))))
     (macroexpand . ,(iter-lambda (args env)
-                      (let* ((form (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
-                             (macro-def (when (and (consp form) (symbolp (car form)))
-                                          (gethash (car form) macher-agent-sandbox--functions))))
-                        (if (and (consp macro-def) (eq (car macro-def) 'macro))
-                            (iter-yield-from (macher-agent-sandbox--funcall-iter (cdr macro-def) (cdr form)))
-                          form))))
+                                 (let* ((form (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env)))
+                                        (macro-def (when (and (consp form) (symbolp (car form)))
+                                                     (gethash (car form) macher-agent-sandbox--functions))))
+                                   (if (and (consp macro-def) (eq (car macro-def) 'macro))
+                                       (iter-yield-from (macher-agent-sandbox--funcall-iter (cdr macro-def) (cdr form)))
+                                     form))))
     (functionp . ,(iter-lambda (args env)
-                    (let ((val (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))))
-                      (or (and (consp val) (memq (car val) '(closure lambda macro)))
-                          (and (symbolp val)
-                               (or (gethash val macher-agent-sandbox--primitives)
-                                   (gethash val macher-agent-sandbox--functions)
-                                   (and (fboundp 'macher-agent--ptc-primitive-p)
-                                        (macher-agent--ptc-primitive-p val))))
-                          (functionp val))))))
+                               (let ((val (iter-yield-from (macher-agent-sandbox--eval-iter (car args) env))))
+                                 (or (and (consp val) (memq (car val) '(closure lambda macro)))
+                                     (and (symbolp val)
+                                          (or (gethash val macher-agent-sandbox--primitives)
+                                              (gethash val macher-agent-sandbox--functions)
+                                              (and (fboundp 'macher-agent--ptc-primitive-p)
+                                                   (macher-agent--ptc-primitive-p val))))
+                                     (functionp val))))))
   "Store mapping of special form symbols to handler functions.
 
 This alist maps special form symbols (such as quote, let, if, cond, and so on)
@@ -506,7 +506,7 @@ Side effects: Signals an error if EXPRESSION is an unbound variable."
         val)))))
 
 (iter-defun macher-agent-sandbox--eval-compound-iter (expression environment)
-  "Evaluate compound form EXPRESSION in ENVIRONMENT.
+            "Evaluate compound form EXPRESSION in ENVIRONMENT.
 
 Evaluate Lisp list expression EXPRESSION by dispatching to PTC tool calls,
 special forms, macros, or standard function invocations.
@@ -516,32 +516,32 @@ ENVIRONMENT is the current lexical environment alist.
 
 Return the evaluated result of the compound form.
 Side effects: May yield tool call interrupts or mutate global sandbox state."
-  (let* ((operator (car expression))
-         (arguments (cdr expression))
-         (special-handler (and (symbolp operator)
-                               (cdr (assoc operator macher-agent-sandbox--special-forms))))
-         (macro-def (and (symbolp operator)
-                         (gethash operator macher-agent-sandbox--functions))))
-    (cond
-     ((and (symbolp operator)
-           (fboundp 'macher-agent--ptc-primitive-p)
-           (macher-agent--ptc-primitive-p operator))
-      (let ((evaled-args (iter-yield-from (macher-agent-sandbox--eval-args-iter arguments environment))))
-        (iter-yield (list :interrupt 'tool-call
-                          :name operator
-                          :args (macher-agent-sandbox--normalize-args-to-plist evaled-args)))))
-     (special-handler
-      (iter-yield-from (funcall special-handler arguments environment)))
-     ((and (consp macro-def) (eq (car macro-def) 'macro))
-      (let* ((macro-fn (cdr macro-def))
-             (expanded-form (iter-yield-from (macher-agent-sandbox--funcall-iter macro-fn arguments))))
-        (iter-yield-from (macher-agent-sandbox--eval-iter expanded-form environment))))
-     (t
-      (let ((evaled-args (iter-yield-from (macher-agent-sandbox--eval-args-iter arguments environment))))
-        (iter-yield-from (macher-agent-sandbox--funcall-iter operator evaled-args)))))))
+            (let* ((operator (car expression))
+                   (arguments (cdr expression))
+                   (special-handler (and (symbolp operator)
+                                         (cdr (assoc operator macher-agent-sandbox--special-forms))))
+                   (macro-def (and (symbolp operator)
+                                   (gethash operator macher-agent-sandbox--functions))))
+              (cond
+               ((and (symbolp operator)
+                     (fboundp 'macher-agent--ptc-primitive-p)
+                     (macher-agent--ptc-primitive-p operator))
+                (let ((evaled-args (iter-yield-from (macher-agent-sandbox--eval-args-iter arguments environment))))
+                  (iter-yield (list :interrupt 'tool-call
+                                    :name operator
+                                    :args (macher-agent-sandbox--normalize-args-to-plist evaled-args)))))
+               (special-handler
+                (iter-yield-from (funcall special-handler arguments environment)))
+               ((and (consp macro-def) (eq (car macro-def) 'macro))
+                (let* ((macro-fn (cdr macro-def))
+                       (expanded-form (iter-yield-from (macher-agent-sandbox--funcall-iter macro-fn arguments))))
+                  (iter-yield-from (macher-agent-sandbox--eval-iter expanded-form environment))))
+               (t
+                (let ((evaled-args (iter-yield-from (macher-agent-sandbox--eval-args-iter arguments environment))))
+                  (iter-yield-from (macher-agent-sandbox--funcall-iter operator evaled-args)))))))
 
 (iter-defun macher-agent-sandbox--eval-iter (expression environment)
-  "Evaluate EXPRESSION in ENVIRONMENT yielding on PTC tool calls.
+            "Evaluate EXPRESSION in ENVIRONMENT yielding on PTC tool calls.
 
 Initialise the sandbox environment and evaluate EXPRESSION based on whether
 it is a literal atom, symbol, or compound form.
@@ -551,14 +551,14 @@ ENVIRONMENT is the current lexical environment alist.
 
 Return the evaluated result of EXPRESSION.
 Side effects: May initialise sandbox state and yield on tool interrupts."
-  (macher-agent-sandbox--init)
-  (cond
-   ((or (numberp expression) (stringp expression) (memq expression '(t nil)))
-    expression)
-   ((symbolp expression)
-    (macher-agent-sandbox--eval-symbol expression environment))
-   ((consp expression)
-    (iter-yield-from (macher-agent-sandbox--eval-compound-iter expression environment)))))
+            (macher-agent-sandbox--init)
+            (cond
+             ((or (numberp expression) (stringp expression) (memq expression '(t nil)))
+              expression)
+             ((symbolp expression)
+              (macher-agent-sandbox--eval-symbol expression environment))
+             ((consp expression)
+              (iter-yield-from (macher-agent-sandbox--eval-compound-iter expression environment)))))
 
 (provide 'macher-agent-sandbox)
 ;;; macher-agent-sandbox.el ends here

--- a/macher-agent.el
+++ b/macher-agent.el
@@ -1,7 +1,7 @@
 ;;; macher-agent.el --- Sandboxed, Language-Agnostic AI Workflows -*- lexical-binding: t; -*-
 
 ;; Author: Elijah Charles
-;; Version: 0.8.0.79
+;; Version: 0.8.0.85
 ;; Package-Requires: ((emacs "30.1") (gptel "0.9.9.6") (macher "0.5.2"))
 ;; Keywords: convenience, gptel, llm, macher
 ;; URL: https://github.com/elij/macher-agent

--- a/skills/scripts/delegate_tasks_to_subagents.el
+++ b/skills/scripts/delegate_tasks_to_subagents.el
@@ -1,34 +1,32 @@
 (macher-agent-make-tool
- macher-agent-delegate-tasks-to-subagents-tool
- "Delegate tasks to multiple sub-agents asynchronously. Use this tool if you need feedback from the agent after \
-execution. Spawn agents before calling."
- :category "collaboration"
- :args (list '(:name "tasks" :type array :items
-                     (:type object :properties
-                            (:buffer_name (:type string)
-                                          :instructions (:type string)
-                                          :presets (:type array :items (:type string))))))
- :command-fn
- (lambda (payload _context _root)
-   (let* ((raw-tasks (plist-get payload :tasks))
-          (normalized-tasks
-           (cl-loop for task-obj in (append raw-tasks nil)
-                    collect (list
-                             :buffer_name (plist-get task-obj :buffer_name)
-                             :instructions (plist-get task-obj :instructions)
-                             :presets (append (plist-get task-obj :presets) nil)
-                             :suppress_patch t))))
-     (make-macher-agent-delegate-response :payload (vconcat normalized-tasks))))
- :success-fn
- (lambda (results)
-   (let ((output (list "All sub-agents completed. Outputs:\n")))
-     (cl-loop for res across (if (vectorp results) results (vconcat results))
-              do (push
-                  (format "=== Response from %s ===%s\n"
-                          (macher-agent-tool-response-buffer-name res)
-                          (if (eq
-                               (macher-agent-tool-response-status res) 'success)
-                              (macher-agent-tool-response-data res)
-                            (macher-agent-tool-response-error res)))
-                  output))
-     (string-join (nreverse output) "\n"))))
+    macher-agent-delegate-tasks-to-subagents-tool
+    "Delegate tasks to multiple sub-agents asynchronously. Use this tool if you need \
+feedback from the agent after execution. Spawn agents before calling."
+  :category "collaboration"
+  :args (list '(:name "tasks" :type array :items
+                      (:type object :properties
+                             (:buffer_name (:type string)
+                                           :instructions (:type string)))))
+  :command-fn
+  (lambda (payload _context _root)
+    (let* ((raw-tasks (plist-get payload :tasks))
+           (normalized-tasks
+            (cl-loop for task-obj in (append raw-tasks nil)
+                     collect (list
+                              :buffer_name (plist-get task-obj :buffer_name)
+                              :instructions (plist-get task-obj :instructions)
+                              :suppress_patch t))))
+      (make-macher-agent-delegate-response :payload (vconcat normalized-tasks))))
+  :success-fn
+  (lambda (results)
+    (let ((output (list "All sub-agents completed. Outputs:\n")))
+      (cl-loop for res across (if (vectorp results) results (vconcat results))
+               do (push
+                   (format "=== Response from %s ===\n%s\n" 
+                           (macher-agent-tool-response-buffer-name res)
+                           (if (eq
+                                (macher-agent-tool-response-status res) 'success)
+                               (macher-agent-tool-response-data res)
+                             (macher-agent-tool-response-error res)))
+                   output))
+      (string-join (nreverse output) "\n"))))

--- a/skills/scripts/list_available_tools.el
+++ b/skills/scripts/list_available_tools.el
@@ -1,0 +1,17 @@
+(macher-agent-make-tool
+    macher-agent-list-available-tools-tool
+    "List all registered gptel-tools in the current workspace. Use this to discover tools to assign to a preset."
+  :category "perception"
+  :args nil
+  :command-fn
+  (lambda (_payload _context _root)
+    (let ((tools-list nil))
+      (maphash (lambda (name tool)
+                 (push (format "- %s: %s" name (gptel-tool-description tool)) tools-list))
+               (if (bound-and-true-p macher-agent-tools-registry)
+                   macher-agent-tools-registry
+                 (make-hash-table)))
+      (if tools-list
+          (string-join (nreverse tools-list) "\n")
+        "No tools registered.")))
+  :success-fn (lambda (res _payload) (format "SUCCESS:\n%s" res)))

--- a/skills/scripts/read_context_audit_log.el
+++ b/skills/scripts/read_context_audit_log.el
@@ -1,0 +1,46 @@
+(macher-agent-make-tool
+    macher-agent-read-context-audit-log-tool
+    "Read the ephemeral tool-intent log from the current task context to evaluate past subagent behaviour. Analyses parameters to determine why previous tasks failed."
+  :category "perception"
+  :args
+  '((:name "preset"
+           :type string
+           :description "Filter by specific preset name (for example, 'PandasDataFilter')."
+           :optional t)
+    (:name "limit"
+           :type integer
+           :description "Max records to return. Defaults to 5."
+           :optional t))
+  :command-fn
+  (lambda (payload context _root)
+    (require 'json)
+    (let* ((preset (plist-get payload :preset))
+           (preset-str (when-let* ((p preset)
+                                   ((not (eq p :json-false)))
+                                   ((stringp p))
+                                   ((not (string-empty-p p))))
+                         p))
+           (raw-limit (plist-get payload :limit))
+           (limit (if (and (numberp raw-limit) (> raw-limit 0))
+                      (round raw-limit)
+                    5))
+           (raw-log (macher-agent--get-context-data context :audit-log))
+           (filtered-log
+            (if preset-str
+                (cl-remove-if-not
+                 (lambda (entry)
+                   (when-let* ((val (cdr (or (assoc 'preset entry)
+                                             (assoc :preset entry)
+                                             (assoc "preset" entry)))))
+                     (let* ((str-val (format "%s" val))
+                            (clean-val (if (string-prefix-p ":" str-val)
+                                           (substring str-val 1)
+                                         str-val)))
+                       (string-equal clean-val preset-str))))
+                 raw-log)
+              raw-log))
+           (recent-entries (last filtered-log limit)))
+      (json-encode (vconcat recent-entries))))
+  :success-fn
+  (lambda (res _payload)
+    (format "SUCCESS: Audit log retrieved.\n%s" res)))

--- a/skills/scripts/read_tool_schema.el
+++ b/skills/scripts/read_tool_schema.el
@@ -1,0 +1,13 @@
+(macher-agent-make-tool
+    macher-agent-read-tool-schema-tool
+    "Get the exact parameter schema for a specific tool. Use this to understand what a tool does before adding it to a preset."
+  :category "perception"
+  :args '((:name "tool_name" :type string :description "The exact string name of the tool to inspect."))
+  :command-fn
+  (lambda (payload _context _root)
+    (let* ((tool-name (plist-get payload :tool_name))
+           (tool (gethash tool-name macher-agent-tools-registry)))
+      (if tool
+          (json-encode (gptel-tool-args tool))
+        (format "ERROR: Tool '%s' not found." tool-name))))
+  :success-fn (lambda (res _payload) (format "SCHEMA: %s" res)))

--- a/skills/scripts/submit_task_result.el
+++ b/skills/scripts/submit_task_result.el
@@ -1,22 +1,21 @@
 (macher-agent-make-tool
- macher-agent-submit-task-result-tool
- "Submit the final result of your assigned task back to the orchestrator."
- :category "event"
- :args '((:name "final_answer" :type string :description "The final answer, data, or \
-summary of completed work."))
- :command-fn
- (lambda (payload _context _root)
-   (when-let* ((final_answer (plist-get payload :final_answer))
-               ((boundp 'macher-agent--parent-callback))
-               (callback macher-agent--parent-callback))
-
-     (funcall callback
-              (make-macher-agent-tool-response
-               :status 'success
-               :data final_answer
-               :buffer-name (buffer-name (current-buffer))))
-
-     (setq-local macher-agent-task-finished t)
-
-     final_answer))
- :success-fn (lambda (_res _payload) "SUCCESS: Result submitted."))
+    macher-agent-submit-task-result-tool
+    "Submit the final result of your assigned task back to the orchestrator."
+  :category "event"
+  :args '((:name "final_answer" :type string :description "The final answer, data, or summary of completed work."))
+  :command-fn
+  (lambda (payload _context _root)
+    (let ((final_answer (plist-get payload :final_answer)))
+      
+      (setq-local macher-agent--task-result final_answer)
+      (setq-local macher-agent-task-finished t)
+      
+      (when-let* (((boundp 'macher-agent--parent-callback))
+                  (callback macher-agent--parent-callback))
+        (funcall callback
+                 (make-macher-agent-tool-response
+                  :status 'success
+                  :data final_answer
+                  :buffer-name (buffer-name (current-buffer)))))
+      final_answer))
+  :success-fn (lambda (_res _payload) "SUCCESS: Result submitted. Yielding control."))

--- a/tests/macher-agent-audit-log-test.el
+++ b/tests/macher-agent-audit-log-test.el
@@ -1,0 +1,80 @@
+;;; macher-agent-audit-log-test.el --- Tests for macher-agent audit logging -*- lexical-binding: t -*-
+
+(require 'buttercup)
+(require 'json)
+(require 'cl-lib)
+(require 'macher-agent)
+
+(load (expand-file-name "skills/scripts/read_context_audit_log.el") nil t)
+
+(describe "Macher-Agent Audit Logging"
+
+  (describe "macher-agent-log-tool-intent"
+    (it "appends entries with timestamp buffer preset type target args into context data audit log"
+      (let ((ctx (macher--make-context))
+            (macher-agent--active-skill-sym 'alpha-preset))
+        (macher-agent-log-tool-intent ctx "gptel-tool" "tool-one" '(:key "value-one"))
+        (let* ((log (macher-agent--get-context-data ctx :audit-log))
+               (entry (car log)))
+          (expect (length log) :to-equal 1)
+          (expect (cdr (assoc 'buffer entry)) :to-equal (buffer-name))
+          (expect (cdr (assoc 'preset entry)) :to-equal "alpha-preset")
+          (expect (cdr (assoc 'type entry)) :to-equal "gptel-tool")
+          (expect (cdr (assoc 'target entry)) :to-equal "tool-one")
+          (expect (cdr (assoc 'args entry)) :to-equal '(:key "value-one"))
+          (expect (stringp (cdr (assoc 'timestamp entry))) :to-be t))
+        (macher-agent-log-tool-intent ctx "gptel-tool" "tool-two" '(:key "value-two"))
+        (expect (length (macher-agent--get-context-data ctx :audit-log)) :to-equal 2))))
+
+  (describe "macher-agent--log-gptel-pre-tool"
+    (it "logs standard gptel tool calls into active context audit log"
+      (let ((ctx (macher--make-context)))
+        (spy-on 'macher-agent-resolve-context :and-return-value ctx)
+        (macher-agent--log-gptel-pre-tool 'test-gptel-tool nil :param "val")
+        (let* ((log (macher-agent--get-context-data ctx :audit-log))
+               (entry (car log)))
+          (expect (length log) :to-equal 1)
+          (expect (cdr (assoc 'type entry)) :to-equal "gptel-tool")
+          (expect (cdr (assoc 'target entry)) :to-equal "test-gptel-tool")
+          (expect (cdr (assoc 'args entry)) :to-equal '(:param "val"))))))
+
+  (describe "macher-agent-sandbox-run"
+    (it "logs PTC tool yields into active context audit log"
+      (let ((ctx (macher--make-context))
+            (macher-agent--active-ptc-primitives '(test-ptc-tool)))
+        (spy-on 'macher-agent-resolve-context :and-return-value ctx)
+        (macher-agent-sandbox-run '(test-ptc-tool :path "file.txt") nil)
+        (let* ((log (macher-agent--get-context-data ctx :audit-log))
+               (entry (car log)))
+          (expect (length log) :to-equal 1)
+          (expect (cdr (assoc 'type entry)) :to-equal "ptc")
+          (expect (cdr (assoc 'target entry)) :to-equal 'test-ptc-tool)
+          (expect (cdr (assoc 'args entry)) :to-equal '(:path "file.txt"))))))
+
+  (describe "macher-agent-read-context-audit-log-tool"
+    (it "filters audit log by preset and limit returning JSON string of entries"
+      (let ((ctx (macher--make-context))
+            (callback-result nil))
+        (spy-on 'macher-agent-resolve-context :and-return-value ctx)
+        (let ((macher-agent--active-skill-sym 'PresetAlpha))
+          (macher-agent-log-tool-intent ctx "gptel-tool" "tool-1" '(:a 1)))
+        (let ((macher-agent--active-skill-sym 'PresetBeta))
+          (macher-agent-log-tool-intent ctx "gptel-tool" "tool-2" '(:b 2)))
+        (let ((macher-agent--active-skill-sym 'PresetAlpha))
+          (macher-agent-log-tool-intent ctx "gptel-tool" "tool-3" '(:c 3)))
+        (let ((macher-agent--active-skill-sym 'PresetAlpha))
+          (macher-agent-log-tool-intent ctx "gptel-tool" "tool-4" '(:d 4)))
+        (funcall (gptel-tool-function macher-agent-read-context-audit-log-tool)
+                 (lambda (res) (setq callback-result res))
+                 :preset "PresetAlpha" :limit 2)
+        (expect callback-result :to-match "SUCCESS: Audit log retrieved.")
+        (when-let* ((lines (split-string callback-result "\n"))
+                    (json-str (cadr lines))
+                    (parsed (json-read-from-string json-str)))
+          (expect (length parsed) :to-equal 2)
+          (let ((first-entry (elt parsed 0))
+                (second-entry (elt parsed 1)))
+            (expect (cdr (assoc 'target first-entry)) :to-equal "tool-3")
+            (expect (cdr (assoc 'target second-entry)) :to-equal "tool-4")
+            (expect (cdr (assoc 'preset first-entry)) :to-equal "PresetAlpha")
+            (expect (cdr (assoc 'preset second-entry)) :to-equal "PresetAlpha")))))))

--- a/tests/macher-agent-full-integration-test.el
+++ b/tests/macher-agent-full-integration-test.el
@@ -46,41 +46,50 @@ CALL-COUNTER is a symbol bound in the calling environment that increments upon F
                       ;; Run asynchronously to process background tool queues
                       (run-at-time 0.01 nil
                                    (lambda ()
-                                     (plist-put info :http-status "200")
-                                     (plist-put info :status "200 OK")
-                                     (gptel--fsm-transition fsm) ;; WAIT -> TYPE
+                                     ;; FIX: Prevent use-after-free if the test suite already killed the buffer!
+                                     (when (buffer-live-p (plist-get info :buffer))
+                                       (plist-put info :http-status "200")
+                                       (plist-put info :status "200 OK")
+                                       (gptel--fsm-transition fsm) ;; WAIT -> TYPE
 
-                                     (if resp
-                                         (progn
-                                           (when (plist-get resp :tool-use)
-                                             ;; Dynamically map our positional mock values to the correct 
-                                             ;; schema keys declared by the tool.
-                                             (let ((tool-use-list nil))
-                                               (cl-loop for tool-req in (plist-get resp :tool-use)
-                                                        for i from 1
-                                                        do
-                                                        (let* ((tool-name (car tool-req))
-                                                               (tool-vals (cdr tool-req))
-                                                               (tool-spec (cl-find-if (lambda (ts) (equal (gptel-tool-name ts) tool-name))
-                                                                                      (plist-get info :tools)))
-                                                               (expected-args (gptel-tool-args tool-spec))
-                                                               (args-plist nil))
-                                                          (cl-loop for arg in expected-args
-                                                                   for val in tool-vals
-                                                                   do (setq args-plist (plist-put args-plist (intern (concat ":" (if (symbolp (plist-get arg :name)) (symbol-name (plist-get arg :name)) (plist-get arg :name)))) val)))
-                                                          (push (list :id (format "call_%s_%d" current-buf i)
-                                                                      :name tool-name
-                                                                      :args args-plist)
-                                                                tool-use-list)))
-                                               (plist-put info :tool-use (nreverse tool-use-list))))
+                                       (if resp
+                                           (progn
+                                             (when (plist-get resp :tool-use)
+                                               ;; map our positional mock values to the correct 
+                                               ;; schema keys declared by the tool.
+                                               (let ((tool-use-list nil))
+                                                 (cl-loop for tool-req in (plist-get resp :tool-use)
+                                                          for i from 1
+                                                          do
+                                                          (let* ((tool-name (car tool-req))
+                                                                 (tool-vals (cdr tool-req))
+                                                                 (tool-spec (or (cl-find-if (lambda (ts) (equal (gptel-tool-name ts) tool-name))
+                                                                                            (plist-get info :tools))
+                                                                                (ignore-errors (gptel-get-tool tool-name))))
+                                                                 (expected-args (when tool-spec (gptel-tool-args tool-spec)))
+                                                                 (args-plist nil))
+                                                            
+                                                            (when tool-spec
+                                                              (unless (cl-find-if (lambda (ts) (equal (gptel-tool-name ts) tool-name)) (plist-get info :tools))
+                                                                (setq info (plist-put info :tools (append (plist-get info :tools) (list tool-spec))))
+                                                                (setf (gptel-fsm-info fsm) info)))
 
-                                           (if (plist-get resp :text)
-                                               (funcall callback (plist-get resp :text) info)
-                                             (funcall callback nil info)))
-                                       (funcall callback "Fallback mock response." info))
+                                                            (cl-loop for arg in expected-args
+                                                                     for val in tool-vals
+                                                                     do (setq args-plist (plist-put args-plist (intern (concat ":" (if (symbolp (plist-get arg :name)) (symbol-name (plist-get arg :name)) (plist-get arg :name)))) val)))
+                                                            (push (list :id (format "call_%s_%d" current-buf i)
+                                                                        :name tool-name
+                                                                        :args args-plist)
+                                                                  tool-use-list)))
+                                                 (plist-put info :tool-use (nreverse tool-use-list))))
 
-                                     (gptel--fsm-transition fsm) ;; TYPE -> TOOL or DONE
-                                     (cl-incf ,call-counter))))))
+                                             (if (plist-get resp :text)
+                                                 (funcall callback (plist-get resp :text) info)
+                                               (funcall callback nil info)))
+                                         (funcall callback "Fallback mock response." info))
+
+                                       (gptel--fsm-transition fsm) ;; TYPE -> TOOL or DONE
+                                       (cl-incf ,call-counter)))))))
                  ;; Map curl fetcher to the exact same mock to guarantee coverage
                  ((symbol-function 'gptel-curl-get-response)
                   (symbol-function 'gptel--url-get-response)))

--- a/tests/macher-agent-resilience-test.el
+++ b/tests/macher-agent-resilience-test.el
@@ -1,0 +1,162 @@
+;;; macher-agent-resilience-test.el --- Resilience tests for macher-agent -*- lexical-binding: t -*-
+
+(require 'buttercup)
+(require 'cl-lib)
+(require 'macher-agent)
+(require 'macher-agent-gptel-bridge)
+(require 'macher-agent-vfs-client)
+(require 'macher-agent-orchestration)
+
+(describe "Macher-Agent Resilience Specifications"
+
+          (describe "1. Test Suite Resilience: The Headless Timer Trap"
+                    (defvar active-timers nil)
+
+                    (after-each
+                     (dolist (timer active-timers)
+                       (when (timerp timer)
+                         (cancel-timer timer)))
+                     (setq active-timers nil)
+                     (dolist (timer timer-list)
+                       (when (timerp timer)
+                         (cancel-timer timer))))
+
+                    (it "enforces liveness checks in asynchronous callbacks"
+                        (let* ((buf (generate-new-buffer "test-resilience-timer-liveness"))
+                               (executed nil)
+                               (callback (lambda ()
+                                           (when (buffer-live-p buf)
+                                             (setq executed t)))))
+                          (with-current-buffer buf
+                            (setq executed nil))
+                          (funcall callback)
+                          (expect executed :to-be t)
+                          (kill-buffer buf)
+                          (setq executed nil)
+                          (funcall callback)
+                          (expect executed :to-be nil)))
+
+                    (it "handles killed buffers gracefully without throwing errors when executing pending handlers"
+                        (let* ((buf (generate-new-buffer "test-resilience-terminal-parity"))
+                               (timer (with-current-buffer buf
+                                        (macher-agent--schedule-buffer-reap buf))))
+                          (push timer active-timers)
+                          (kill-buffer buf)
+                          (expect (lambda () (funcall (timer--function timer))) :not :to-throw))))
+
+          (describe "2. LLM Payload Edge Cases: The Nil-Response Guardrail"
+                    (it "coerces nil text responses to empty strings when valid tool use is present"
+                        (let* ((captured-response "unset")
+                               (captured-info nil)
+                               (mock-orig-fun (lambda (resp info &optional _raw)
+                                                (setq captured-response resp)
+                                                (setq captured-info info)
+                                                "success")))
+                          (expect (macher-agent--protect-nil-responses
+                                   mock-orig-fun
+                                   nil
+                                   (list :tool-use '((:name "execute_command"))))
+                                  :to-equal "success")
+                          (expect captured-response :to-equal "")
+                          (expect (plist-get captured-info :tool-use) :to-be-truthy)))
+
+                    (it "handles tool-only sub-agent responses during silent delegation"
+                        (let* ((buf (generate-new-buffer "test-resilience-subagent-silent"))
+                               (success-called nil)
+                               (error-called nil)
+                               (hook-fn (macher-agent--make-transmit-response-hook
+                                         (lambda (res) (setq success-called res))
+                                         (lambda (err) (setq error-called err)))))
+                          (with-current-buffer buf
+                            (setq-local macher-agent--is-subagent t)
+                            (insert "Tool execution result payload")
+                            (funcall hook-fn (point-min) (point-max)))
+                          (expect success-called :to-equal "Tool execution result payload")
+                          (expect error-called :to-be nil)
+                          (when (buffer-live-p buf)
+                            (kill-buffer buf)))))
+
+          (describe "3. JIT Composition Boundaries: State Bleed Prevention"
+                    (it "preserves permanent buffer gptel-system-prompt without inline tag bleed or Skill wrappers"
+                        (let* ((orig-buf (generate-new-buffer "test-resilience-state-bleed-orig"))
+                               (base-sys "Permanent Clean System Directive")
+                               (temp-buf (generate-new-buffer "test-resilience-state-bleed-temp")))
+                          (with-current-buffer orig-buf
+                            (setq-local gptel-system-prompt base-sys)
+                            (setq-local gptel-model 'test-model)
+                            (setq-local gptel-tools nil)
+                            (insert "@elisp-expert Perform task with inline tag"))
+                          (with-current-buffer temp-buf
+                            (let ((fsm (gptel-make-fsm)))
+                              (setf (gptel-fsm-info fsm) (list :buffer orig-buf))
+                              (macher-agent-sync-prompt-transformer nil fsm)))
+                          (with-current-buffer orig-buf
+                            (expect gptel-system-prompt :to-equal base-sys)
+                            (expect (string-match-p "PROGRAMMATIC TOOL CALLING" gptel-system-prompt) :to-be nil)
+                            (expect (string-match-p "@elisp-expert" gptel-system-prompt) :to-be nil))
+                          (when (buffer-live-p orig-buf) (kill-buffer orig-buf))
+                          (when (buffer-live-p temp-buf) (kill-buffer temp-buf))))
+
+                    (it "verifies sub-agent buffer gptel-system-prompt matches directive registered in gptel-directives"
+                        (let* ((directive-key 'resilience-test-directive)
+                               (directive-msg "Subagent Directive System Message")
+                               (old-directives (default-value 'gptel-directives))
+                               (old-presets (default-value 'gptel--known-presets))
+                               (parent-buf (generate-new-buffer "test-resilience-parent"))
+                               (sub-buf nil))
+                          (unwind-protect
+                              (progn
+                                (setq-default gptel-directives (cons (cons directive-key directive-msg) old-directives))
+                                (setq-default gptel--known-presets (cons (cons directive-key (list :system directive-msg)) old-presets))
+                                (with-current-buffer parent-buf
+                                  (setq-local gptel-directives (default-value 'gptel-directives))
+                                  (setq-local gptel--known-presets (default-value 'gptel--known-presets))
+                                  (setq sub-buf (macher-agent-add-subagent "test-resilience-subagent-directive" (list directive-key))))
+                                (with-current-buffer sub-buf
+                                  (expect gptel-system-prompt :to-equal directive-msg)))
+                            (setq-default gptel-directives old-directives)
+                            (setq-default gptel--known-presets old-presets)
+                            (when (buffer-live-p parent-buf) (kill-buffer parent-buf))
+                            (when (buffer-live-p sub-buf) (kill-buffer sub-buf))))))
+
+          (describe "4. VFS and Context Resolution: The Hidden Buffer Trap"
+                    (it "extracts orig-buf context from FSM inside temporary transmission buffer"
+                        (let* ((temp-dir (file-name-as-directory (make-temp-file "macher-resilience-ctx-" t)))
+                               (workspace (make-macher-agent-workspace :project-root temp-dir))
+                               (ctx (macher--make-context :workspace workspace :contents nil))
+                               (orig-buf (generate-new-buffer "test-resilience-orig-buf"))
+                               (trans-buf (generate-new-buffer "test-resilience-trans-buf"))
+                               (fsm (gptel-make-fsm))
+                               (resolved-ctx nil))
+                          (puthash (expand-file-name temp-dir) ctx macher-agent-active-workspaces)
+                          (setf (gptel-fsm-info fsm) (list :buffer orig-buf :macher-agent-context ctx))
+                          (with-current-buffer trans-buf
+                            (setq resolved-ctx (macher-agent-resolve-context fsm)))
+                          (expect resolved-ctx :to-equal ctx)
+                          (when (buffer-live-p orig-buf) (kill-buffer orig-buf))
+                          (when (buffer-live-p trans-buf) (kill-buffer trans-buf))
+                          (delete-directory temp-dir t)))
+
+                    (it "clears VFS memory after Emacs cache desync is resolved by buffer revert"
+                        (let* ((temp-dir (file-name-as-directory (make-temp-file "macher-resilience-desync-" t)))
+                               (file-path (expand-file-name "desync-target.txt" temp-dir))
+                               (initial-text "Initial File Content\n")
+                               (updated-text "Updated VFS Content\n"))
+                          (write-region initial-text nil file-path nil 'silent)
+                          (let* ((file-buf (find-file-noselect file-path))
+                                 (workspace (make-macher-agent-workspace :project-root temp-dir))
+                                 (ctx (macher--make-context :workspace workspace :contents nil)))
+                            (puthash (expand-file-name temp-dir) ctx macher-agent-active-workspaces)
+                            (macher-agent-vfs-write workspace file-path updated-text)
+                            (expect (macher-agent--get-context-dirty-p ctx) :to-be t)
+                            (write-region updated-text nil file-path nil 'silent)
+                            (macher-agent--auto-sync-context ctx)
+                            (expect (macher-agent--get-context-dirty-p ctx) :to-be t)
+                            (with-current-buffer file-buf
+                              (revert-buffer t t))
+                            (macher-agent--auto-sync-context ctx)
+                            (expect (macher-agent--get-context-dirty-p ctx) :to-be nil)
+                            (when (buffer-live-p file-buf) (kill-buffer file-buf)))
+                          (delete-directory temp-dir t)))))
+
+(provide 'macher-agent-resilience-test)


### PR DESCRIPTION
- removed string matching for presets
- added buffer locals to compose state
- only use clean system prompts active buffer
- added primitives to network fsm
- add meta tools for audit/tool registry (https://arxiv.org/abs/2605.22148)