### PR TITLE
chore(fsm): movved fsm into macher-agent-gptel

### DIFF
--- a/macher-agent-api.el
+++ b/macher-agent-api.el
@@ -155,7 +155,7 @@ TYPE is the invocation type string, such as gptel-tool or ptc.
 TARGET is the tool identifier name string or PTC primitive symbol.
 ARGS is the list of parameters passed to the tool.
 
-Return the updated audit log list.
+Return the updated audit log list, or nil if CONTEXT is invalid.
 
 Side effects: Mutates CONTEXT audit log property list."
   (when (and context (macher-agent-context-p context))
@@ -173,45 +173,24 @@ Side effects: Mutates CONTEXT audit log property list."
                     (preset . ,preset-str)
                     (type . ,type)
                     (target . ,target)
-                    (args . ,args))))
+                    (args . ,args)))
+           (updated-log (append log (list entry))))
       (setf (macher-agent-context-plugins context)
-            (plist-put (copy-sequence plugins) :audit-log (append log (list entry)))))))
-
-(defun macher-agent--log-gptel-pre-tool (tool &optional fsm &rest args)
-  "Log GPTEL pre-tool call intent to context audit log.
-
-TOOL is the tool structure or property list.
-FSM is the optional state machine object.
-ARGS represents additional arguments passed to the tool call.
-
-Return nil.
-
-Side effects: Appends tool call entry to active context audit log."
-  (let ((context (or (when fsm (or (macher-agent-gptel--fsm-context fsm)
-                                   (ignore-errors (macher-agent-resolve-context fsm))))
-                     (bound-and-true-p macher-agent--persistent-context)
-                     (ignore-errors (macher-agent-resolve-context (current-buffer)))
-                     (ignore-errors (macher-agent-resolve-context))))
-        (tool-name (macher-agent-canonical-tool-name tool))
-        (tool-args (if (and (macher-agent--plist-p tool) (plist-member tool :args))
-                       (plist-get tool :args)
-                     args)))
-    (when context
-      (macher-agent-log-tool-intent context "gptel-tool" tool-name tool-args))))
+            (plist-put (copy-sequence plugins) :audit-log updated-log))
+      updated-log)))
 
 (defun macher-agent-force-review (&optional context)
   "Trigger task flush hook for pending reviews.
 
 CONTEXT is the optional active context structure.  When nil, resolves
-the active context.
+the active context from `macher-agent--persistent-context'.
 
 Return nil.
 
 Side effects: Invokes task flush hooks."
   (interactive)
   (let ((ctx (or context
-                 (bound-and-true-p macher-agent--persistent-context)
-                 (ignore-errors (macher-agent-resolve-context)))))
+                 (bound-and-true-p macher-agent--persistent-context))))
     (macher-agent-run-task-flush-hook ctx)))
 
 
@@ -225,40 +204,53 @@ Side effects: Invokes task flush hooks."
   (declare (indent 1) (debug t))
   `(let ((root-buf (get-buffer-create ,buffer-name))
          (allowed-primitives ,primitives)
-         (active-presets ,presets))
+         (active-presets ,presets)
+         (caller-buf (current-buffer)))
      (with-current-buffer root-buf
        (unless (bound-and-true-p macher-agent--persistent-context)
-         (setq-local macher-agent--persistent-context
-                     (macher-agent--make-context :id "proxy-ctx" :project-root default-directory)))
-       (when (fboundp 'macher-agent-resolve-tools)
-         (macher-agent-resolve-tools macher-agent--persistent-context active-presets))
-       (let ((native-fsm (gptel-request nil :dry-run t))
-             (script-str (prin1-to-string ',(if (> (length script-body) 1)
+         (setq macher-agent--persistent-context
+               (or (macher-agent-context-from-buffer caller-buf)
+                   (macher-agent--make-context :id "proxy-ctx" :project-root default-directory))))
+
+       (if (fboundp 'markdown-mode)
+           (markdown-mode)
+         (text-mode))
+       (when (fboundp 'gptel-mode)
+         (gptel-mode 1))
+
+       (when (buffer-live-p caller-buf)
+         (setq-local gptel-model (buffer-local-value 'gptel-model caller-buf))
+         (setq-local gptel-backend (buffer-local-value 'gptel-backend caller-buf))
+         (setq-local gptel-temperature (buffer-local-value 'gptel-temperature caller-buf))
+         (setq-local gptel-max-tokens (buffer-local-value 'gptel-max-tokens caller-buf))
+         (setq-local gptel--known-presets (buffer-local-value 'gptel--known-presets caller-buf))
+         (setq-local gptel-directives (buffer-local-value 'gptel-directives caller-buf)))
+
+       (when (fboundp 'macher-agent-initialize-skills)
+         (macher-agent-initialize-skills macher-agent--persistent-context))
+       (when active-presets
+         (setq-local macher-agent-presets active-presets)
+         (macher-agent--apply-preset active-presets))
+
+       (setq macher-agent--active-ptc-primitives allowed-primitives)
+
+       (let ((script-str (prin1-to-string ',(if (> (length script-body) 1)
                                                 `(progn ,@script-body)
                                               (car script-body))))
              (success-cb (or ,on-success (lambda (res) (message "PTC Success: %s" res))))
              (error-cb (or ,on-error (lambda (err) (message "PTC Error: %s" err)))))
 
-         (cl-letf (((symbol-function 'macher-agent-get-active-fsm)
-                    (lambda (&rest _) native-fsm))
-                   ((symbol-function 'macher-agent--ptc-primitive-p)
-                    (lambda (sym &rest _)
-                      (or (memq sym allowed-primitives)
-                          (and (fboundp 'macher-agent-sandbox--primitives)
-                               (hash-table-p macher-agent-sandbox--primitives)
-                               (gethash sym macher-agent-sandbox--primitives))))))
-
-           (macher-agent-execute-ptc-script
-            script-str
-            macher-agent--persistent-context
-            (lambda (res)
-              (funcall success-cb res)
-              (when ,reap (kill-buffer root-buf)))
-            (lambda (err)
-              (funcall error-cb err)
-              (when ,reap (kill-buffer root-buf)))
-            nil
-            root-buf))))))
+         (macher-agent-execute-ptc-script
+          script-str
+          macher-agent--persistent-context
+          root-buf
+          (lambda (res)
+            (funcall success-cb res)
+            (when ,reap (kill-buffer root-buf)))
+          (lambda (err)
+            (funcall error-cb err)
+            (when ,reap (kill-buffer root-buf)))
+          nil)))))
 
 (provide 'macher-agent-api)
 ;;; macher-agent-api.el ends here

--- a/macher-agent-core.el
+++ b/macher-agent-core.el
@@ -12,8 +12,6 @@
 (eval-and-compile
   (require 'gv))
 
-(declare-function gptel-fsm-p "gptel" (obj))
-(declare-function gptel-fsm-info "gptel" (fsm))
 (declare-function gptel-tool-p "gptel" (tool))
 (declare-function gptel-tool-name "gptel" (tool))
 (declare-function project-current "project" (&optional maybe-prompt dir))
@@ -27,6 +25,7 @@
   (id nil :type (or null string))
   (project-root nil :type (or null string))
   (origin-buffer nil :type (or null buffer))
+  (prompt nil :type (or null string))
   (tools nil :type list)
   (skills nil :type list)
   (media-queue nil :type list)
@@ -187,12 +186,6 @@ Side effects: None.")
   :group 'macher-agent)
 
 ;; Buffer-local agent state
-(defvar-local macher-agent--active-fsm nil
-  "Store active finite-state machine (FSM) instance for current buffer.
-
-Return active FSM struct or nil.
-Side effects: Buffer-local variable.")
-
 (defvar-local macher-agent--routing-stack nil
   "Stack of routing frame property lists for current sub-agent buffer.
 
@@ -309,16 +302,6 @@ Side effects: Buffer-local variable.")
   "Initial boot directive instruction string for sub-agent execution.
 
 Return the boot directive string or nil.
-
-Side effects: Buffer-local variable.")
-
-(defvar-local macher-agent-fsm-id nil
-  "Buffer-local identifier bridging user interface buffers to the state machine.
-
-Stores the unique state machine identifier associated with the current
-user interface buffer session.
-
-Return the state machine identifier string or symbol, or nil if unassigned.
 
 Side effects: Buffer-local variable.")
 
@@ -454,73 +437,6 @@ Return non-nil if OBJECT is a valid plist, otherwise nil."
                (setq lst (cddr lst))))
            (and valid (null lst))))))
 
-(defun macher-agent-get-active-fsm (&optional current-fsm)
-  "Resolve the active finite-state machine.
-Use CURRENT-FSM or buffer-local active FSM."
-  (or (and current-fsm
-           (not (macher-agent-transit-payload-p current-fsm))
-           (not (macher-agent-context-p current-fsm))
-           (not (bufferp current-fsm))
-           (not (stringp current-fsm))
-           current-fsm)
-      (bound-and-true-p macher-agent--active-fsm)
-      (bound-and-true-p gptel--fsm)))
-
-(defun macher-agent--extract-fsm-info (fsm)
-  "Extract gptel info plist safely enforcing standard keys."
-  (cond
-   ((null fsm) nil)
-   ((and (fboundp 'gptel-fsm-p) (gptel-fsm-p fsm))
-    (gptel-fsm-info fsm))
-   ((and (recordp fsm) (fboundp 'gptel-fsm-info))
-    (ignore-errors (gptel-fsm-info fsm)))
-   ((macher-agent--plist-p fsm)
-    (let ((ctx (plist-get fsm :macher-agent-context))
-          (buf (plist-get fsm :buffer)))
-      (when (or ctx buf)
-        (list :macher-agent-context ctx :buffer buf))))
-   (t nil)))
-
-(defun macher-agent--set-fsm-info (fsm info)
-  "Safely update the info property list of finite-state machine FSM to INFO.
-
-FSM is the finite-state machine instance or structure.
-INFO is the new info property list value.
-
-Return INFO when FSM is non-nil, or nil when FSM is nil.
-Side effects: Modifies the info slot of FSM."
-  (when fsm
-    (cond
-     ((fboundp 'set-gptel-fsm-info)
-      (set-gptel-fsm-info fsm info))
-     ((or (recordp fsm) (vectorp fsm))
-      (when (> (length fsm) 4)
-        (aset fsm 4 info)))
-     ((fboundp '\(setf\ gptel-fsm-info\))
-      (\(setf\ gptel-fsm-info\) info fsm))
-     (t nil))
-    info))
-
-(defun macher-agent--set-fsm-handlers (fsm handlers)
-  "Safely update the handlers alist of finite-state machine FSM to HANDLERS.
-
-FSM is the finite-state machine instance or structure.
-HANDLERS is the new handlers alist.
-
-Return HANDLERS when FSM is non-nil, or nil when FSM is nil.
-Side effects: Modifies the handlers slot of FSM."
-  (when fsm
-    (cond
-     ((fboundp 'set-gptel-fsm-handlers)
-      (set-gptel-fsm-handlers fsm handlers))
-     ((or (recordp fsm) (vectorp fsm))
-      (when (> (length fsm) 3)
-        (aset fsm 3 handlers)))
-     ((fboundp '\(setf\ gptel-fsm-handlers\))
-      (\(setf\ gptel-fsm-handlers\) handlers fsm))
-     (t nil))
-    handlers))
-
 (defun macher-agent-valid-context-p (context)
   "Determine whether CONTEXT is a valid persistent context structure.
 
@@ -531,18 +447,6 @@ Return non-nil if CONTEXT is a `macher-agent-context', or nil otherwise.
 Side effects: None."
   (macher-agent-context-p context))
 
-(defun macher-agent-context-prompt (ctx)
-  "Retrieve prompt from context CTX.
-
-CTX is the `macher-agent-context' structure.
-
-Return prompt string, or nil.
-Side effects: None."
-  (when (macher-agent-context-p ctx)
-    (let ((plugins (macher-agent-context-plugins ctx)))
-      (when (macher-agent--plist-p plugins)
-        (plist-get plugins :prompt)))))
-
 (defun set-macher-agent-context-prompt (ctx val)
   "Set prompt on context CTX to VAL.
 
@@ -550,14 +454,10 @@ CTX is the `macher-agent-context' structure.
 VAL is the prompt string.
 
 Return VAL on success, or nil.
-Side effects: Updates `:prompt' in `macher-agent-context-plugins'."
+Side effects: Sets the prompt slot on CTX."
   (when (macher-agent-context-p ctx)
-    (let* ((plugins (macher-agent-context-plugins ctx))
-           (updated (plist-put (copy-sequence plugins) :prompt val)))
-      (setf (macher-agent-context-plugins ctx) updated)))
+    (setf (macher-agent-context-prompt ctx) val))
   val)
-
-(gv-define-simple-setter macher-agent-context-prompt set-macher-agent-context-prompt)
 
 (defun macher-agent-context-workspace (ctx)
   "Retrieve the tagged workspace structure from context CTX.
@@ -593,36 +493,6 @@ Side effects: None."
            (s-ws (when (macher-agent--plist-p shared) (plist-get shared :workspace))))
       (or ws-id ws t-ws proj s-ws-id s-ws)))
    (t nil)))
-
-(defun macher-agent--extract-fsm-context (fsm)
-  "Extract active context from FSM enforcing strict keys."
-  (cond
-   ((null fsm) nil)
-   ((macher-agent-valid-context-p fsm) fsm)
-   (t (let* ((info (macher-agent--extract-fsm-info fsm)))
-        (when (macher-agent--plist-p info)
-          (or (plist-get info :macher-agent-context)
-              (plist-get info :context)
-              (condition-case nil
-                  (macher-agent-resolve-from-transit-payload info)
-                (error nil))))))))
-
-(defun macher-agent--transform-inject-context (async-fn fsm)
-  "Inject the originating buffer context into the FSM info list.
-This function executes in the detached *gptel-prompt* buffer. It retrieves
-the context from the originating buffer stored in the FSM."
-  (let* ((info (if (and (fboundp 'gptel-fsm-p) (gptel-fsm-p fsm))
-                   (gptel-fsm-info fsm)
-                 (when (fboundp 'gptel-fsm-info) (gptel-fsm-info fsm))))
-         (target-buf (when (macher-agent--plist-p info) (plist-get info :buffer))))
-    (when (and target-buf (buffer-live-p target-buf))
-      (with-current-buffer target-buf
-        (setq macher-agent--active-fsm fsm))
-      (let ((ctx (buffer-local-value 'macher-agent--persistent-context target-buf)))
-        (when (and ctx (macher-agent-valid-context-p ctx))
-          (when (fboundp 'macher-agent--inject-context-into-fsm-info)
-            (funcall 'macher-agent--inject-context-into-fsm-info ctx fsm))))))
-  (funcall async-fn))
 
 (defvar macher-agent-task-flush-hook nil
   "Hook run when an agent task flushes or completes its execution cycle.
@@ -755,22 +625,43 @@ Return the constructed and validated `macher-agent-transit-payload' struct."
    :payload (or payload message)
    :metadata metadata))
 
-(defun macher-agent-resolve-from-transit-payload (payload-or-state)
-  "Extract context from PAYLOAD-OR-STATE using transit keys.
-Reject invalid payloads with an error signal rather than falling
-back to nil silently."
-  (cond
-   ((macher-agent-valid-context-p payload-or-state)
-    payload-or-state)
+(defun macher-agent-context-from-buffer (buffer)
+  "Extract the persistent `macher-agent-context' from BUFFER.
 
-   ((macher-agent-transit-payload-p payload-or-state)
-    (or (let ((c (macher-agent-transit-payload-target-context payload-or-state)))
+BUFFER is the buffer object or buffer name string to inspect.
+
+Return the `macher-agent-context' structure stored in BUFFER's
+`macher-agent--persistent-context', or nil if BUFFER is invalid,
+not live, or context is unset.
+
+Side effects: None."
+  (let ((buf (if (bufferp buffer) buffer (and (stringp buffer) (get-buffer buffer)))))
+    (when (and buf (buffer-live-p buf))
+      (let ((ctx (buffer-local-value 'macher-agent--persistent-context buf)))
+        (when (macher-agent-valid-context-p ctx)
+          ctx)))))
+
+(defun macher-agent-context-from-payload (payload)
+  "Extract the active `macher-agent-context' from PAYLOAD.
+
+PAYLOAD is a `macher-agent-transit-payload' structure or a `macher-agent-context' structure.
+
+Return the resolved `macher-agent-context' structure.
+Signals an error if PAYLOAD is invalid or no context can be resolved.
+
+Side effects: None."
+  (cond
+   ((macher-agent-valid-context-p payload)
+    payload)
+
+   ((macher-agent-transit-payload-p payload)
+    (or (let ((c (macher-agent-transit-payload-target-context payload)))
           (when (macher-agent-valid-context-p c) c))
-        (let ((c (macher-agent-transit-payload-parent-context payload-or-state)))
+        (let ((c (macher-agent-transit-payload-parent-context payload)))
           (when (macher-agent-valid-context-p c) c))
-        (let ((c (macher-agent-transit-payload-child-context payload-or-state)))
+        (let ((c (macher-agent-transit-payload-child-context payload)))
           (when (macher-agent-valid-context-p c) c))
-        (let ((shared (macher-agent-transit-payload-shared-state payload-or-state)))
+        (let ((shared (macher-agent-transit-payload-shared-state payload)))
           (when (macher-agent--plist-p shared)
             (or (let ((c (plist-get shared :target-context)))
                   (when (macher-agent-valid-context-p c) c))
@@ -780,13 +671,21 @@ back to nil silently."
                   (when (macher-agent-valid-context-p c) c))
                 (let ((c (plist-get shared :context)))
                   (when (macher-agent-valid-context-p c) c)))))
-        (let* ((b-raw (macher-agent-transit-payload-target-buffer payload-or-state))
+        (let* ((b-raw (macher-agent-transit-payload-target-buffer payload))
                (buf (when b-raw (if (bufferp b-raw) b-raw (and (stringp b-raw) (get-buffer b-raw))))))
           (when (and buf (buffer-live-p buf))
             (let ((bctx (buffer-local-value 'macher-agent--persistent-context buf)))
               (when (macher-agent-valid-context-p bctx) bctx))))
-        (error "Cannot resolve context from transit payload: %S" payload-or-state)))
+        (error "Cannot resolve context from transit payload: %S" payload)))
 
+   (t
+    (error "Invalid transit payload: expected context or transit payload struct, got %S" payload))))
+
+(defun macher-agent-resolve-from-transit-payload (payload-or-state)
+  "Extract context from PAYLOAD-OR-STATE using transit keys.
+Reject invalid payloads with an error signal rather than falling
+back to nil silently."
+  (cond
    ((and (macher-agent--plist-p payload-or-state)
          (plist-member payload-or-state :resolved)
          (plist-member payload-or-state :input))
@@ -795,55 +694,13 @@ back to nil silently."
       (let* ((input (plist-get payload-or-state :input))
              (ctx (when input
                     (condition-case nil
-                        (macher-agent-resolve-from-transit-payload input)
+                        (macher-agent-context-from-payload input)
                       (error nil)))))
         (if (and ctx (macher-agent-valid-context-p ctx))
             (plist-put payload-or-state :resolved ctx)
           payload-or-state))))
-
    (t
-    (error "Invalid transit payload: expected context or transit payload struct, got %S" payload-or-state))))
-
-(defun macher-agent-resolve-context (&optional input)
-  "Resolve the active `macher-agent-context'.
-
-If INPUT is a valid `macher-agent-context' structure, return it directly.
-If INPUT is a live buffer, read `macher-agent--persistent-context' from it.
-If INPUT is a `macher-agent-transit-payload', resolve context from its slots.
-If INPUT or the active execution environment has an active FSM via
-`macher-agent-get-active-fsm', extract the context from the FSM payload.
-If `macher-agent--persistent-context' is non-nil in the current buffer,
-return it.
-Otherwise return nil.
-
-Side effects: None."
-  (cond
-   ((macher-agent-valid-context-p input)
-    input)
-   ((and (bufferp input) (buffer-live-p input))
-    (let ((ctx (buffer-local-value 'macher-agent--persistent-context input)))
-      (when (macher-agent-valid-context-p ctx)
-        ctx)))
-   ((macher-agent-transit-payload-p input)
-    (or (let ((c (macher-agent-transit-payload-target-context input)))
-          (when (macher-agent-valid-context-p c) c))
-        (let ((c (macher-agent-transit-payload-parent-context input)))
-          (when (macher-agent-valid-context-p c) c))
-        (let ((c (macher-agent-transit-payload-child-context input)))
-          (when (macher-agent-valid-context-p c) c))
-        (when-let* ((b (macher-agent-transit-payload-target-buffer input))
-                    (buf (if (bufferp b) b (and (stringp b) (get-buffer b)))))
-          (when (and buf (buffer-live-p buf))
-            (let ((ctx (buffer-local-value 'macher-agent--persistent-context buf)))
-              (when (macher-agent-valid-context-p ctx) ctx))))))
-   ((when-let* ((fsm (macher-agent-get-active-fsm input))
-                (ctx (macher-agent--extract-fsm-context fsm)))
-      (when (macher-agent-valid-context-p ctx)
-        ctx)))
-   ((when-let* ((ctx (bound-and-true-p macher-agent--persistent-context)))
-      (when (macher-agent-valid-context-p ctx)
-        ctx)))
-   (t nil)))
+    (macher-agent-context-from-payload payload-or-state))))
 
 (defun macher-agent-root (&optional path)
   "Resolve absolute project root path from PATH.

--- a/macher-agent-gptel.el
+++ b/macher-agent-gptel.el
@@ -21,6 +21,22 @@
 (defvar macher-agent-token-multiplier 4
   "Estimated characters per token used for context truncation.")
 
+(defvar-local macher-agent--active-fsm nil
+  "Store active finite-state machine (FSM) instance for current buffer.
+
+Return active FSM struct or nil.
+Side effects: Buffer-local variable.")
+
+(defvar-local macher-agent-fsm-id nil
+  "Buffer-local identifier bridging user interface buffers to the state machine.
+
+Stores the unique state machine identifier associated with the current
+user interface buffer session.
+
+Return the state machine identifier string or symbol, or nil if unassigned.
+
+Side effects: Buffer-local variable.")
+
 (defvar-local macher-agent--is-restored-session nil
   "Track whether current buffer is restored from a saved state.
 
@@ -133,9 +149,13 @@ Side effects: None."
              collect (cons state
                            (cond
                             ((eq state 'WAIT)
-                             (cons #'macher-agent--inject-media-fsm-logic funcs))
+                             (if (memq #'macher-agent--inject-media-fsm-logic funcs)
+                                 funcs
+                               (cons #'macher-agent--inject-media-fsm-logic funcs)))
                             ((memq state '(DONE ERRS ABRT))
-                             (append funcs (list #'macher-agent-gptel--trigger-flush)))
+                             (if (memq #'macher-agent-gptel--trigger-flush funcs)
+                                 funcs
+                               (append funcs (list #'macher-agent-gptel--trigger-flush))))
                             (t funcs))))))
       (macher-agent--set-fsm-handlers fsm augmented-handlers)
       (setf (gptel-fsm-handlers fsm) augmented-handlers)))
@@ -492,7 +512,7 @@ and transforms prompt."
                  (ignore-errors (gptel-fsm-info fsm-obj))))
          (orig-buf (or (and info (plist-get info :buffer)) temp-buf))
          (context (or (when active-fsm
-                        (macher-agent-gptel--fsm-context active-fsm orig-buf))
+                        (macher-agent-gptel-context-from-fsm active-fsm orig-buf))
                       (when (and orig-buf (buffer-live-p orig-buf))
                         (buffer-local-value 'macher-agent--persistent-context orig-buf)))))
 
@@ -531,15 +551,18 @@ and transforms prompt."
                  inline-preset-used prompt-start inline-skills))
 
                (state (macher-agent--compile-transmission-payload
-                       orig-buf buffer-presets transmission-skills redirected-skill context)))
+                       orig-buf buffer-presets transmission-skills redirected-skill context))
+               (payload (list :model (macher-agent-transmission-state-model state)
+                              :backend (with-current-buffer orig-buf (bound-and-true-p gptel-backend))
+                              :temperature (macher-agent-transmission-state-temperature state)
+                              :max-tokens (macher-agent-transmission-state-max-tokens state)
+                              :tools (macher-agent-transmission-state-tools state)
+                              :ptc-primitives (macher-agent-transmission-state-ptc-primitives state))))
 
-          (macher-agent--apply-payload-locally
-           (list :model (macher-agent-transmission-state-model state)
-                 :backend (with-current-buffer orig-buf (bound-and-true-p gptel-backend))
-                 :temperature (macher-agent-transmission-state-temperature state)
-                 :max-tokens (macher-agent-transmission-state-max-tokens state)
-                 :tools (macher-agent-transmission-state-tools state)
-                 :ptc-primitives (macher-agent-transmission-state-ptc-primitives state)))
+          (with-current-buffer orig-buf
+            (macher-agent--apply-payload-locally payload))
+
+          (macher-agent--apply-payload-locally payload)
 
           (when-let* ((compiled (macher-agent-transmission-state-compiled-prompt state)))
             (setq-local gptel-system-prompt compiled))
@@ -745,10 +768,15 @@ Side effects: Modifies `gptel-system-prompt', adds response hook, and
 calls `gptel-send'."
   (let* ((target-buffer (macher-agent-task-context-target-buffer task-context))
          (sys-msg (macher-agent-task-context-system-message task-context))
+         (ctx (when (and target-buffer (buffer-live-p target-buffer))
+                (buffer-local-value 'macher-agent--persistent-context target-buffer)))
          (success-cb (or (plist-get callbacks :on-success)
                          (plist-get callbacks :success-cb)))
          (error-cb (or (plist-get callbacks :on-error)
                        (plist-get callbacks :error-cb))))
+    (when (and ctx (macher-agent-valid-context-p ctx) sys-msg)
+      (unless (macher-agent-context-prompt ctx)
+        (setf (macher-agent-context-prompt ctx) sys-msg)))
     (with-current-buffer target-buffer
       (when sys-msg
         (setq-local gptel-system-prompt sys-msg))
@@ -767,14 +795,18 @@ Prevent recursive media injection loops during state transitions.")
 (defun macher-agent-gptel--fsm-target-buffer (fsm)
   "Extract target buffer from FSM safely."
   (when fsm
-    (let* ((info (ignore-errors (gptel-fsm-info fsm))))
+    (let* ((info (ignore-errors (macher-agent--extract-fsm-info fsm))))
       (when (macher-agent--plist-p info)
-        (plist-get info :buffer)))))
+        (or (plist-get info :origin-buffer)
+            (plist-get info :buffer))))))
 
-(defun macher-agent-gptel--fsm-context (&optional fsm target-buf)
-  "Extract context from FSM or fallback buffer.
-During active execution, resolve directly from FSM info plist :macher-agent-context.
-When idle or in resting state, resolve from `macher-agent--persistent-context'."
+(defun macher-agent-gptel-context-from-fsm (fsm &optional target-buf)
+  "Extract `macher-agent-context' strictly from FSM structures or fallback to buffer persistence.
+
+FSM is the finite-state machine instance or context structure.
+TARGET-BUF is an optional buffer used as a fallback.
+
+Return the resolved `macher-agent-context' struct, or nil."
   (cond
    ((null fsm)
     (let ((buf (or target-buf (current-buffer))))
@@ -793,6 +825,43 @@ When idle or in resting state, resolve from `macher-agent--persistent-context'."
        ((and buf (buffer-live-p buf))
         (let ((bctx (buffer-local-value 'macher-agent--persistent-context buf)))
           (when (macher-agent-valid-context-p bctx) bctx))))))))
+
+(defun macher-agent-gptel-spoof-tool-ui (target-buf tool-name)
+  "Manipulate mode line display for PTC tool call TOOL-NAME in TARGET-BUF within the gptel layer.
+
+TARGET-BUF is the target buffer for tool execution.
+TOOL-NAME is the symbol or string name of the executed tool.
+
+Return non-nil on success.
+Side effects: Updates gptel mode line status in TARGET-BUF."
+  (let* ((buf (cond ((bufferp target-buf) target-buf)
+                    ((stringp target-buf) (get-buffer target-buf))
+                    (t (current-buffer))))
+         (name-str (replace-regexp-in-string "_" "-" (if (symbolp tool-name) (symbol-name tool-name) (format "%s" tool-name)))))
+    (when (and buf (buffer-live-p buf))
+      (with-current-buffer buf
+        (let ((fsm (or (macher-agent-get-active-fsm)
+                       (bound-and-true-p macher-agent--active-fsm)
+                       (bound-and-true-p gptel--fsm-last))))
+          (if (and fsm (fboundp 'gptel-fsm-info) (fboundp 'gptel--update-tool-call))
+              (let* ((info (gptel-fsm-info fsm))
+                     (mock-info (copy-sequence info))
+                     (spoofed-calls (list (list :name (format "PTC: %s" name-str)))))
+                (setq mock-info (plist-put mock-info :tool-use spoofed-calls))
+                (setq mock-info (plist-put mock-info :buffer buf))
+
+                (unwind-protect
+                    (progn
+                      (macher-agent--set-fsm-info fsm mock-info)
+                      (gptel--update-tool-call fsm))
+                  (macher-agent--set-fsm-info fsm info)))
+            (when (fboundp 'gptel--update-status)
+              (gptel--update-status
+               (concat
+                (propertize " Calling tool (" 'face 'mode-line-emphasis)
+                (propertize (format "PTC: %s" name-str) 'face 'font-lock-keyword-face)
+                (propertize ")" 'face 'mode-line-emphasis))))))
+        t))))
 
 (defun macher-agent--perform-pending-media-injection (fsm)
   "Inject base64 media directly into FSM payload enforcing a strict string contract."
@@ -901,13 +970,34 @@ Return a block list if TOOL is out of scope, otherwise nil.
 Side effects: None."
   (let* ((canonical-name (macher-agent-canonical-tool-name tool))
          (fsm-obj (macher-agent-get-active-fsm fsm))
-         (info (when fsm-obj (gptel-fsm-info fsm-obj)))
-         (fsm-tools (when info (plist-get info :tools)))
+         (info (when fsm-obj (ignore-errors (gptel-fsm-info fsm-obj))))
+         (fsm-tools (or (when info (plist-get info :tools))
+                        (bound-and-true-p gptel-tools)))
          (authorised-names (mapcar #'macher-agent-canonical-tool-name fsm-tools)))
     (unless (and canonical-name (member canonical-name authorised-names))
       (list
        :block (format "ERROR: Tool '%s' is not accessible in this context or is no longer available. Please select another tool or approach."
                       (or canonical-name tool))))))
+
+(defun macher-agent--log-gptel-pre-tool (tool &optional fsm &rest args)
+  "Log GPTEL pre-tool call intent to context audit log.
+
+TOOL is the tool structure or property list.
+FSM is the optional state machine object.
+ARGS represents additional arguments passed to the tool call.
+
+Return nil.
+
+Side effects: Appends tool call entry to active context audit log."
+  (let ((context (or (when fsm (macher-agent-gptel-context-from-fsm fsm))
+                     (macher-agent-gptel-context-from-fsm (macher-agent-get-active-fsm))
+                     (bound-and-true-p macher-agent--persistent-context)))
+        (tool-name (macher-agent-canonical-tool-name tool))
+        (tool-args (if (and (macher-agent--plist-p tool) (plist-member tool :args))
+                       (plist-get tool :args)
+                     args)))
+    (when (and context (fboundp 'macher-agent-log-tool-intent))
+      (macher-agent-log-tool-intent context "gptel-tool" tool-name tool-args))))
 
 (defvar macher-agent--wrapped-tools-hash (make-hash-table :test 'eq)
   "Track wrapped `gptel-tool' instances in a hash table.
@@ -1004,7 +1094,7 @@ Side effects: Mutates function slot of TOOL and updates
                                          (ignore-errors (plist-get (gptel-fsm-info fsm) :buffer)))
                                        (current-buffer)))
                        (agent-ctx (or (when fsm
-                                        (macher-agent-gptel--fsm-context fsm target-buf))
+                                        (macher-agent-gptel-context-from-fsm fsm target-buf))
                                       (when (and target-buf (buffer-live-p target-buf))
                                         (buffer-local-value 'macher-agent--persistent-context target-buf)))))
 
@@ -1229,8 +1319,8 @@ Side effects: Creates new chat buffer and sets buffer-local agent variables."
         (setq-local macher-agent--active-skill-sym skill))
 
       (setq-local macher-agent-presets (with-current-buffer parent-buf macher-agent-presets))
-      (setq-local macher-agent--active-ptc-primitives
-                  (with-current-buffer parent-buf macher-agent--active-ptc-primitives))
+      (setq macher-agent--active-ptc-primitives
+            (with-current-buffer parent-buf macher-agent--active-ptc-primitives))
       (setq-local gptel-tools (with-current-buffer parent-buf gptel-tools))
 
       (switch-to-buffer (current-buffer)))))
@@ -1303,7 +1393,7 @@ Side effects: Mutates info property list of the active backend FSM if bound."
   (when (and fsm (fboundp 'gptel-fsm-state) (memq (gptel-fsm-state fsm) '(DONE ERRS ABRT)))
     (let* ((info (ignore-errors (gptel-fsm-info fsm)))
            (target-buf (when (macher-agent--plist-p info) (plist-get info :buffer)))
-           (agent-ctx (or (macher-agent-gptel--fsm-context fsm target-buf)
+           (agent-ctx (or (macher-agent-gptel-context-from-fsm fsm target-buf)
                           (when (and target-buf (buffer-live-p target-buf))
                             (buffer-local-value 'macher-agent--persistent-context target-buf)))))
       (when (and target-buf (buffer-live-p target-buf))
@@ -1312,6 +1402,91 @@ Side effects: Mutates info property list of the active backend FSM if bound."
           (setq-local macher-agent--pending-instructions-queue nil)))
       (when agent-ctx
         (macher-agent-run-task-flush-hook agent-ctx)))))
+
+(defun macher-agent-get-active-fsm (&optional current-fsm)
+  "Resolve the active finite-state machine.
+Use CURRENT-FSM or buffer-local active FSM."
+  (or (and current-fsm
+           (not (macher-agent-transit-payload-p current-fsm))
+           (not (macher-agent-context-p current-fsm))
+           (not (bufferp current-fsm))
+           (not (stringp current-fsm))
+           current-fsm)
+      (bound-and-true-p macher-agent--active-fsm)
+      (bound-and-true-p gptel--fsm)))
+
+(defun macher-agent--extract-fsm-info (fsm)
+  "Extract gptel info plist safely enforcing standard keys."
+  (cond
+   ((null fsm) nil)
+   ((and (fboundp 'gptel-fsm-p) (gptel-fsm-p fsm))
+    (gptel-fsm-info fsm))
+   ((and (recordp fsm) (fboundp 'gptel-fsm-info))
+    (ignore-errors (gptel-fsm-info fsm)))
+   ((macher-agent--plist-p fsm)
+    (let ((ctx (or (plist-get fsm :macher-agent-context) (plist-get fsm :context)))
+          (orig-buf (or (plist-get fsm :origin-buffer) (plist-get fsm :buffer)))
+          (buf (or (plist-get fsm :buffer) (plist-get fsm :origin-buffer))))
+      (when (or ctx orig-buf buf)
+        (list :macher-agent-context ctx :origin-buffer orig-buf :buffer buf))))
+   (t nil)))
+
+(defun macher-agent--set-fsm-info (fsm info)
+  "Safely update the info property list of finite-state machine FSM to INFO.
+
+FSM is the finite-state machine instance or structure.
+INFO is the new info property list value.
+
+Return INFO when FSM is non-nil, or nil when FSM is nil.
+Side effects: Modifies the info slot of FSM."
+  (when fsm
+    (cond
+     ((fboundp 'set-gptel-fsm-info)
+      (set-gptel-fsm-info fsm info))
+     ((or (recordp fsm) (vectorp fsm))
+      (when (> (length fsm) 4)
+        (aset fsm 4 info)))
+     ((fboundp '\(setf\ gptel-fsm-info\))
+      (\(setf\ gptel-fsm-info\) info fsm))
+     (t nil))
+    info))
+
+(defun macher-agent--set-fsm-handlers (fsm handlers)
+  "Safely update the handlers alist of finite-state machine FSM to HANDLERS.
+
+FSM is the finite-state machine instance or structure.
+HANDLERS is the new handlers alist.
+
+Return HANDLERS when FSM is non-nil, or nil when FSM is nil.
+Side effects: Modifies the handlers slot of FSM."
+  (when fsm
+    (cond
+     ((fboundp 'set-gptel-fsm-handlers)
+      (set-gptel-fsm-handlers fsm handlers))
+     ((or (recordp fsm) (vectorp fsm))
+      (when (> (length fsm) 3)
+        (aset fsm 3 handlers)))
+     ((fboundp '\(setf\ gptel-fsm-handlers\))
+      (\(setf\ gptel-fsm-handlers\) handlers fsm))
+     (t nil))
+    handlers))
+
+(defun macher-agent--transform-inject-context (async-fn fsm)
+  "Inject the originating buffer context into the FSM info list.
+This function executes in the detached *gptel-prompt* buffer. It retrieves
+the context from the originating buffer stored in the FSM."
+  (let* ((info (if (and (fboundp 'gptel-fsm-p) (gptel-fsm-p fsm))
+                   (gptel-fsm-info fsm)
+                 (when (fboundp 'gptel-fsm-info) (gptel-fsm-info fsm))))
+         (target-buf (when (macher-agent--plist-p info) (plist-get info :buffer))))
+    (when (and target-buf (buffer-live-p target-buf))
+      (with-current-buffer target-buf
+        (setq macher-agent--active-fsm fsm))
+      (let ((ctx (buffer-local-value 'macher-agent--persistent-context target-buf)))
+        (when (and ctx (macher-agent-valid-context-p ctx))
+          (when (fboundp 'macher-agent--inject-context-into-fsm-info)
+            (funcall 'macher-agent--inject-context-into-fsm-info ctx fsm))))))
+  (funcall async-fn))
 
 (provide 'macher-agent-gptel)
 ;;; macher-agent-gptel.el ends here

--- a/macher-agent-macher.el
+++ b/macher-agent-macher.el
@@ -15,12 +15,10 @@
 (defvar macher-workspace-functions)
 (defvar macher--workspace)
 
-(declare-function gptel-fsm-info "gptel" (fsm))
-(declare-function gptel-fsm-p "gptel" (obj))
 (declare-function project-root "project" (project))
 (declare-function macher--workspace-hash "macher" (workspace &optional len))
 (declare-function macher--workspace-name "macher" (workspace))
-(declare-function macher--build-patch "macher" (context fsm))
+(declare-function macher--build-patch "macher" (context &optional fsm))
 (declare-function macher--make-context "macher" (&rest args))
 (declare-function make-macher-context "macher" (&rest args))
 (declare-function macher-context-p "macher" (obj))
@@ -137,63 +135,25 @@ Side effects: None."
               (error nil)))
           "workspace"))))
 
-(defun macher-agent-macher-build-patch (&optional arg1 arg2 arg3 &rest _rest)
-  "Bridge upstream `macher--build-patch' with flexible arities.
+(defun macher-agent-macher-build-patch (ctx prompt &optional files)
+  "Build patch for CTX using PROMPT and optional FILES via Macher core.
 
-Accepts:
-- (CTX FSM) where CTX is a `macher-agent-context` (or upstream context)
-- (PROJECT-ROOT FILES FSM)
-- (CTX FSM FILES)
+CTX is a `macher-agent-context` structure.
+PROMPT is the user prompt string.
+FILES is an optional list of `macher-agent-vfs-entry` objects.  If nil,
+extracted from CTX.
 
-Ephemerally instantiates upstream `macher-context` via
-`macher--make-context` with :workspace `(cons \\='agent PROJECT-ROOT)`
-and :contents FILES solely at the moment `macher--build-patch' is called.
+Ephemerally instantiates upstream `macher-context` via `macher--make-context`
+with :workspace `(cons \\='agent PROJECT-ROOT)` and :contents FILES solely at the
+moment `macher--build-patch' is called.
 
 Return the result of upstream patch generation.
 Side effects: Delegates patch building to Macher core."
-  (let* ((is-native-ctx (macher-agent-valid-context-p arg1))
-         (is-upstream-ctx (and (not is-native-ctx) (fboundp 'macher-context-p) (macher-context-p arg1)))
-         (project-root
-          (cond
-           (is-native-ctx
-            (or (macher-agent-context-project-root arg1)
-                (macher-agent-context-root arg1)))
-           (is-upstream-ctx
-            (when (fboundp 'macher-context-workspace)
-              (let ((ws (macher-context-workspace arg1)))
-                (if (consp ws) (cdr ws) ws))))
-           ((and (consp arg1) (memq (car arg1) '(agent project)))
-            (cdr arg1))
-           ((stringp arg1) arg1)
-           (t (macher-agent-workspace-project-root arg1))))
-         (vfs-files
-          (cond
-           ((and (not is-native-ctx) (not is-upstream-ctx) arg3) arg2)
-           (arg3 arg3)
-           (is-native-ctx (macher-agent--get-context-contents arg1))
-           (is-upstream-ctx (when (fboundp 'macher-context-contents)
-                              (macher-context-contents arg1)))
-           (t nil)))
-         (fsm
-          (cond
-           ((and (not is-native-ctx) (not is-upstream-ctx) arg3) arg3)
-           (t arg2)))
-         (prompt
-          (or (when is-native-ctx
-                (or (macher-agent-context-prompt arg1)
-                    (let ((plugins (macher-agent-context-plugins arg1)))
-                      (when (macher-agent--plist-p plugins)
-                        (plist-get plugins :prompt)))))
-              (when is-upstream-ctx
-                (when (fboundp 'macher-context-prompt)
-                  (macher-context-prompt arg1)))
-              (when (and fsm (fboundp 'gptel-fsm-info) (fboundp 'gptel-fsm-p) (gptel-fsm-p fsm))
-                (plist-get (gptel-fsm-info fsm) :prompt))
-              (when (and (listp fsm) (plist-member fsm :prompt))
-                (plist-get fsm :prompt))))
+  (let* ((project-root (or (macher-agent-context-project-root ctx)
+                           (macher-agent-context-root ctx)))
+         (vfs-files (or files (macher-agent--get-context-contents ctx)))
          (raw-root (if (consp project-root) (cdr project-root) project-root))
          (canonical-root (and raw-root (file-truename (expand-file-name raw-root))))
-
          (relative-vfs-files
           (mapcar (lambda (entry)
                     (let* ((path (macher-agent-vfs-entry-path entry))
@@ -205,30 +165,26 @@ Side effects: Delegates patch building to Macher core."
                                        path)))
                       (cons rel-path (cons orig curr))))
                   vfs-files)))
-
     (let ((default-directory (if canonical-root
                                  (file-name-as-directory canonical-root)
                                default-directory)))
-      (if is-upstream-ctx
-          (when (fboundp 'macher--build-patch)
-            (or (funcall 'macher--build-patch arg1 fsm)
-                (macher-agent-macher-patch-buffer arg1)))
-        (let ((ephemeral-ctx
-               (cond
-                ((fboundp 'macher--make-context)
-                 (funcall 'macher--make-context
-                          :workspace (cons 'agent (or canonical-root project-root))
-                          :contents relative-vfs-files
-                          :prompt prompt))
-                ((fboundp 'make-macher-context)
-                 (funcall 'make-macher-context
-                          :workspace (cons 'agent (or canonical-root project-root))
-                          :contents relative-vfs-files
-                          :prompt prompt))
-                (t nil))))
-          (when (fboundp 'macher--build-patch)
-            (or (funcall 'macher--build-patch ephemeral-ctx fsm)
-                (macher-agent-macher-patch-buffer (or ephemeral-ctx (cons 'agent (or canonical-root project-root)))))))))))
+      (let ((ephemeral-ctx
+             (cond
+              ((fboundp 'macher--make-context)
+               (funcall 'macher--make-context
+                        :workspace (cons 'agent (or canonical-root project-root))
+                        :contents relative-vfs-files
+                        :prompt prompt))
+              ((fboundp 'make-macher-context)
+               (funcall 'make-macher-context
+                        :workspace (cons 'agent (or canonical-root project-root))
+                        :contents relative-vfs-files
+                        :prompt prompt))
+              (t nil))))
+        (if (fboundp 'macher--build-patch)
+            (or (funcall 'macher--build-patch ephemeral-ctx nil)
+                (macher-agent-macher-patch-buffer (or ephemeral-ctx (cons 'agent (or canonical-root project-root)))))
+          (macher-agent-macher-patch-buffer (or ephemeral-ctx (cons 'agent (or canonical-root project-root)))))))))
 
 (defun macher-agent-macher-patch-buffer (&optional workspace)
   "Retrieve the active patch buffer for WORKSPACE from Macher core.
@@ -312,34 +268,6 @@ during construction."
               (plist-put (copy-sequence (macher-agent-context-plugins ctx)) :upstream-proxy proxy))))
     ctx))
 
-(defun macher-agent--get-fsm-latest ()
-  "Get the active finite-state machine (FSM) if bound.
-
-Delegates to `macher-agent-get-active-fsm' to locate and return the active
-finite-state machine instance.
-
-Return the active FSM structure, or nil if none is bound.
-
-Side effects: None."
-  (macher-agent-get-active-fsm))
-
-(defun macher-agent--inject-context-into-fsm-info (agent-ctx &optional fsm)
-  "Inject AGENT-CTX into FSM info property list safely.
-
-Store AGENT-CTX in the info plist of finite-state machine FSM
-under key `:macher-agent-context'.
-FSM defaults to active `gptel--fsm'.
-
-Return non-nil if injected successfully, or nil otherwise.
-
-Side effects: Mutates the info property list of FSM."
-  (when-let* ((fsm-obj (macher-agent-get-active-fsm fsm)))
-    (let* ((info (macher-agent--extract-fsm-info fsm-obj))
-           (new-info (if info (copy-sequence info) nil)))
-      (setq new-info (plist-put new-info :macher-agent-context agent-ctx))
-      (macher-agent--set-fsm-info fsm-obj new-info))
-    t))
-
 (defun macher-agent--get-active-workspace ()
   "Retrieve the globally active workspace.
 
@@ -371,7 +299,7 @@ Side effects: May initialise workspace state for current directory."
   (save-excursion
     (when-let* ((current-root (macher-agent-root default-directory)))
       (macher-agent--init-workspace-state current-root)
-      (macher-agent-resolve-context (current-buffer)))))
+      (macher-agent-context-from-buffer (current-buffer)))))
 
 (defun macher-agent--register-active-workspace-root (root context)
   "Register CONTEXT for ROOT in `macher-agent-active-workspaces` hash-table.
@@ -436,26 +364,6 @@ Side effects: None."
                                                   state)
                                               state))))
 
-(defun macher-agent-ctx-pipe--fsm (state)
-  "Context pipeline step 4: Resolve context from FSM input in STATE.
-
-If `:resolved' in STATE is nil and `:input' in STATE is a finite-state machine
-\(FSM), extract and set `:resolved' to its active context structure.
-
-STATE is the context resolution state plist (:input ... :resolved ...).
-
-Return the updated STATE plist.
-Side effects: None."
-  (macher-agent--with-unresolved-ctx-pipe state
-                                          (let ((input (when (macher-agent--plist-p state) (plist-get state :input))))
-                                            (if (and input (or (and (fboundp 'gptel-fsm-p) (gptel-fsm-p input))
-                                                               (and (recordp input) (fboundp 'gptel-fsm-info))
-                                                               (symbolp input)))
-                                                (if-let* ((ctx (macher-agent--extract-fsm-context input)))
-                                                    (plist-put state :resolved ctx)
-                                                  state)
-                                              state))))
-
 (defun macher-agent-ctx-pipe--lazy-init (state)
   "Context pipeline step: Resolve context via lazy initialisation in STATE.
 
@@ -485,7 +393,6 @@ Side effects: May initialise workspace state for current directory."
   (macher-agent-register-pipeline-step 'context-resolution #'macher-agent-ctx-pipe--explicit 10)
   (macher-agent-register-pipeline-step 'context-resolution #'macher-agent-ctx-pipe--buffer 15)
   (macher-agent-register-pipeline-step 'context-resolution #'macher-agent-resolve-from-transit-payload 15)
-  (macher-agent-register-pipeline-step 'context-resolution #'macher-agent-ctx-pipe--fsm 40)
   (macher-agent-register-pipeline-step 'context-resolution #'macher-agent-ctx-pipe--lazy-init 80))
 
 (cl-defun make-macher-agent-workspace (&key project-root &allow-other-keys)
@@ -519,24 +426,30 @@ Side effects: None."
    ((or (macher-agent-context-p ws-or-id) (macher-agent-valid-context-p ws-or-id))
     ws-or-id)
    ((bufferp ws-or-id)
-    (when (buffer-live-p ws-or-id)
-      (let ((ctx (buffer-local-value 'macher-agent--persistent-context ws-or-id)))
-        (when (or (macher-agent-context-p ctx) (macher-agent-valid-context-p ctx))
-          ctx))))
-   ((and (boundp 'macher-agent-active-workspaces)
-         (hash-table-p macher-agent-active-workspaces))
-    (or (when-let* ((ws-id (macher-agent-workspace-project-root ws-or-id)))
-          (let ((exp (expand-file-name ws-id))
-                (true-exp (file-truename (expand-file-name ws-id))))
+    (macher-agent-context-from-buffer ws-or-id))
+   ((stringp ws-or-id)
+    (or (macher-agent-context-from-buffer ws-or-id)
+        (when (and (boundp 'macher-agent-active-workspaces)
+                   (hash-table-p macher-agent-active-workspaces))
+          (let ((exp (expand-file-name ws-or-id))
+                (true-exp (file-truename (expand-file-name ws-or-id))))
             (or (gethash exp macher-agent-active-workspaces)
                 (gethash (file-name-as-directory exp) macher-agent-active-workspaces)
                 (gethash (directory-file-name exp) macher-agent-active-workspaces)
                 (gethash true-exp macher-agent-active-workspaces)
                 (gethash (file-name-as-directory true-exp) macher-agent-active-workspaces)
-                (gethash (directory-file-name true-exp) macher-agent-active-workspaces))))
-        (macher-agent-resolve-context ws-or-id)))
-   (t
-    (macher-agent-resolve-context ws-or-id))))
+                (gethash (directory-file-name true-exp) macher-agent-active-workspaces))))))
+   ((and (boundp 'macher-agent-active-workspaces)
+         (hash-table-p macher-agent-active-workspaces))
+    (when-let* ((ws-id (macher-agent-workspace-project-root ws-or-id)))
+      (let ((exp (expand-file-name ws-id))
+            (true-exp (file-truename (expand-file-name ws-id))))
+        (or (gethash exp macher-agent-active-workspaces)
+            (gethash (file-name-as-directory exp) macher-agent-active-workspaces)
+            (gethash (directory-file-name exp) macher-agent-active-workspaces)
+            (gethash true-exp macher-agent-active-workspaces)
+            (gethash (file-name-as-directory true-exp) macher-agent-active-workspaces)
+            (gethash (directory-file-name true-exp) macher-agent-active-workspaces)))))))
 
 (defun macher-agent--workspace-get-hash-table (ws-or-ctx key &optional default)
   "Retrieve or initialise hash-table under KEY for WS-OR-CTX deterministically.
@@ -545,8 +458,7 @@ WS-OR-CTX is a workspace object or context structure.
 KEY is the lookup key.
 DEFAULT is the default value if unresolved."
   (let ((ctx (or (when (macher-agent-valid-context-p ws-or-ctx) ws-or-ctx)
-                 (macher-agent-context-lookup ws-or-ctx)
-                 (macher-agent-resolve-context ws-or-ctx))))
+                 (macher-agent-context-lookup ws-or-ctx))))
     (if ctx
         (let ((plugins (macher-agent-context-plugins ctx)))
           (or (when (macher-agent--plist-p plugins)
@@ -582,7 +494,6 @@ WS-OR-CTX is a workspace object or context structure.
 
 Return a hash-table."
   (let ((ctx (or (when (macher-agent-valid-context-p ws-or-ctx) ws-or-ctx)
-                 (macher-agent-resolve-context ws-or-ctx)
                  (macher-agent-context-lookup ws-or-ctx))))
     (if ctx
         (let ((tools (macher-agent-context-tools ctx)))
@@ -604,7 +515,6 @@ WS-OR-CTX is a workspace object or context structure.
 
 Return an alist."
   (let ((ctx (or (when (macher-agent-valid-context-p ws-or-ctx) ws-or-ctx)
-                 (macher-agent-resolve-context ws-or-ctx)
                  (macher-agent-context-lookup ws-or-ctx))))
     (if ctx
         (or (macher-agent-context-skills ctx)
@@ -626,7 +536,6 @@ WS-OR-CTX is a workspace object or context structure.
 
 Return a list of subagent entries."
   (when-let* ((ctx (or (when (macher-agent-valid-context-p ws-or-ctx) ws-or-ctx)
-                       (macher-agent-resolve-context ws-or-ctx)
                        (macher-agent-context-lookup ws-or-ctx))))
     (or (macher-agent-context-subagents ctx)
         (let ((plugins (macher-agent-context-plugins ctx)))
@@ -643,7 +552,6 @@ Return VAL.
 Side effects: Modifies the skills alist for WS-OR-CTX if resolvable, or global
 if WS-OR-CTX is nil."
   (if-let* ((ctx (or (when (macher-agent-valid-context-p ws-or-ctx) ws-or-ctx)
-                     (macher-agent-resolve-context ws-or-ctx)
                      (macher-agent-context-lookup ws-or-ctx))))
       (setf (macher-agent-context-skills ctx) val)
     (when (null ws-or-ctx)
@@ -663,7 +571,6 @@ Return VAL.
 Side effects: Modifies tools registry for WS-OR-CTX if resolvable, or global
 if WS-OR-CTX is nil."
   (if-let* ((ctx (or (when (macher-agent-valid-context-p ws-or-ctx) ws-or-ctx)
-                     (macher-agent-resolve-context ws-or-ctx)
                      (macher-agent-context-lookup ws-or-ctx))))
       (setf (macher-agent-context-tools ctx) val)
     (when (null ws-or-ctx)
@@ -682,7 +589,6 @@ VAL is the list of active subagents to set.
 Return VAL.
 Side effects: Modifies the active subagents list for WS-OR-CTX."
   (when-let* ((ctx (or (when (macher-agent-valid-context-p ws-or-ctx) ws-or-ctx)
-                       (macher-agent-resolve-context ws-or-ctx)
                        (macher-agent-context-lookup ws-or-ctx))))
     (setf (macher-agent-context-subagents ctx) val))
   val)
@@ -768,9 +674,8 @@ Side effects: Invokes external process (`git` or `patch`) to apply patch."
   (interactive)
   (unless (derived-mode-p 'diff-mode) (user-error "Not in a patch/diff buffer"))
   (let* ((patch-content (buffer-substring-no-properties (point-min) (point-max)))
-         (ctx (or (bound-and-true-p macher-agent--persistent-context)
-                  (ignore-errors (macher-agent-resolve-context (current-buffer)))
-                  (ignore-errors (macher-agent-resolve-context))))
+         (ctx (or (macher-agent-context-from-buffer (current-buffer))
+                  (bound-and-true-p macher-agent--persistent-context)))
          (root (if ctx
                    (macher-agent-context-root ctx)
                  (or (locate-dominating-file default-directory ".git") default-directory)))

--- a/macher-agent-orchestration.el
+++ b/macher-agent-orchestration.el
@@ -16,6 +16,9 @@
 (require 'macher-agent-tools)
 (require 'macher-agent-presets)
 
+(defvar gptel--known-presets)
+(defvar gptel-directives)
+
 (defvar macher-agent-active-subagents nil
   "Store active sub-agents and their locked directories as an alist.
 
@@ -87,16 +90,11 @@ Return nil.
 
 Side effects: Spawns or signals sub-agent buffers and updates registries."
   (let* ((total (length send-message-payloads))
-         (actual-parent-fsm (macher-agent-get-active-fsm))
-         (actual-parent-buf (or (when actual-parent-fsm
-                                  (ignore-errors (plist-get (gptel-fsm-info actual-parent-fsm) :buffer)))
-                                (current-buffer)))
+         (actual-parent-buf (current-buffer))
          (parent-ctx (or (when (macher-agent-context-p parent-ctx-override) parent-ctx-override)
                          (when (and actual-parent-buf (buffer-live-p actual-parent-buf))
                            (let ((bctx (buffer-local-value 'macher-agent--persistent-context actual-parent-buf)))
-                             (when (macher-agent-context-p bctx) bctx)))
-                         (when actual-parent-fsm
-                           (macher-agent-gptel--fsm-context actual-parent-fsm actual-parent-buf))))
+                             (when (macher-agent-context-p bctx) bctx)))))
          (normalized-payloads
           (mapcar (lambda (msg)
                     (let* ((msg-type (macher-agent-transit-payload-type msg))
@@ -154,11 +152,10 @@ Side effects: Spawns or signals sub-agent buffers and updates registries."
                              :total total
                              :final-callback final-callback
                              :parent-buffer actual-parent-buf
-                             :parent-fsm actual-parent-fsm
                              :parent-context parent-ctx
                              :original-payloads normalized-payloads)))
     (if (= total 0)
-        (when final-callback (funcall final-callback nil))
+        (when final-callback (funcall final-callback []))
       (dolist (msg normalized-payloads)
         (if (eq (macher-agent-transit-payload-type msg) 'ARTIFACT_UPDATE)
             (let* ((tid (macher-agent-transit-payload-task-id msg))
@@ -406,7 +403,7 @@ Side effects: Mutates the text contents of the target buffer."
             (insert (or instructions "") "\n\n"))))
       state)))
 
-(defun macher-agent--aggregate-a2a-results (task-id msg-body results total original-payloads final-callback parent-buf parent-fsm)
+(defun macher-agent--aggregate-a2a-results (task-id msg-body results total original-payloads final-callback parent-buf)
   "Aggregate A2A results and trigger final callback when complete.
 
 TASK-ID is the completed task identifier string.
@@ -416,7 +413,6 @@ TOTAL is the integer count of expected sub-agent tasks.
 ORIGINAL-PAYLOADS is the list of initial dispatch payloads.
 FINAL-CALLBACK is the function invoked with the aggregated results vector.
 PARENT-BUF is the orchestrator parent buffer object.
-PARENT-FSM is the active orchestrator state machine instance.
 
 Return nil.
 
@@ -435,8 +431,7 @@ Side effects: Updates RESULTS hash table."
       (if (and parent-buf (buffer-live-p parent-buf))
           (with-current-buffer parent-buf
             (when final-callback
-              (let ((macher-agent--active-fsm parent-fsm))
-                (funcall final-callback (vconcat ordered-results)))))
+              (funcall final-callback (vconcat ordered-results))))
         (when final-callback
           (funcall final-callback (vconcat ordered-results)))))))
 
@@ -483,7 +478,6 @@ routing stack of the child buffer."
          (parent-name (or (plist-get state :originator-name)
                           (when (and parent-buf (buffer-live-p parent-buf))
                             (buffer-name parent-buf))))
-         (parent-fsm (plist-get shared :parent-fsm))
          (total (or (plist-get shared :total) 1))
          (final-callback (plist-get shared :final-callback))
          (original-payloads (plist-get shared :original-payloads))
@@ -495,7 +489,7 @@ routing stack of the child buffer."
       (setq state (plist-put state :a2a-msg msg)))
 
     (if err-payload
-        (macher-agent--aggregate-a2a-results task-id err-payload results total original-payloads final-callback parent-buf parent-fsm)
+        (macher-agent--aggregate-a2a-results task-id err-payload results total original-payloads final-callback parent-buf)
       (let ((child-buf (plist-get state :child-buf)))
         (when (and child-buf (buffer-live-p child-buf))
           (with-current-buffer child-buf
@@ -518,9 +512,7 @@ routing stack of the child buffer."
 
                             (when (and parent-buf (buffer-live-p parent-buf))
                               (with-current-buffer parent-buf
-                                (let ((parent-ctx (or (bound-and-true-p macher-agent--persistent-context)
-                                                      (when parent-fsm
-                                                        (macher-agent-gptel--fsm-context parent-fsm parent-buf)))))
+                                (let ((parent-ctx (bound-and-true-p macher-agent--persistent-context)))
                                   (when parent-ctx
                                     (setq-local macher-agent--persistent-context parent-ctx)
                                     (if p
@@ -534,12 +526,9 @@ routing stack of the child buffer."
                                                             (macher-agent-transit-payload-target-context artifact-payload)
                                                           (when (macher-agent--plist-p artifact-payload)
                                                             (plist-get artifact-payload :target-context)))))
-                                  (setq-local macher-agent--persistent-context merged-ctx)
-                                  (when parent-fsm
-                                    (when (fboundp 'macher-agent--inject-context-into-fsm-info)
-                                      (macher-agent--inject-context-into-fsm-info merged-ctx parent-fsm))))))
+                                  (setq-local macher-agent--persistent-context merged-ctx))))
 
-                            (macher-agent--aggregate-a2a-results actual-task-id msg-body results total original-payloads final-callback parent-buf parent-fsm))))))
+                            (macher-agent--aggregate-a2a-results actual-task-id msg-body results total original-payloads final-callback parent-buf))))))
                 (puthash task-id a2a-cb macher-agent--pending-callbacks)
                 (macher-agent--push-routing task-id parent-name suppress-patch)
                 (setq state (plist-put state :a2a-cb a2a-cb))))))))
@@ -1189,12 +1178,10 @@ Resolve context, clone it, and determine target directory in STATE."
   (let* ((parent (plist-get state :parent-buffer))
          (dir (plist-get state :dir))
          (ctx (plist-get state :context))
-         (resolved-ctx (or (when (macher-agent-context-p ctx) ctx)
-                           (when-let* ((is-live (buffer-live-p parent)))
-                             (let ((pctx (buffer-local-value 'macher-agent--persistent-context parent)))
-                               (when (macher-agent-context-p pctx) pctx)))
-                           (when (and dir (fboundp 'macher-agent-resolve-context))
-                             (ignore-errors (macher-agent-resolve-context dir)))))
+         (resolved-ctx (or (when (or (macher-agent-context-p ctx) (macher-agent-valid-context-p ctx)) ctx)
+                           (when parent (macher-agent-context-from-buffer parent))
+                           (when (and dir (boundp 'macher-agent-active-workspaces) (hash-table-p macher-agent-active-workspaces))
+                             (gethash (expand-file-name dir) macher-agent-active-workspaces))))
          (cloned-ctx (when-let* ((r-ctx resolved-ctx))
                        (if (fboundp 'macher-agent--clone-context)
                            (macher-agent--clone-context r-ctx)
@@ -1241,12 +1228,8 @@ Resolve context, clone it, and determine target directory in STATE."
         (setq-local
          macher-agent--boot-directive
          (with-current-buffer parent (bound-and-true-p macher-agent--boot-directive)))
-        (if (boundp 'gptel--known-presets)
-            (setq gptel--known-presets (buffer-local-value 'gptel--known-presets parent))
-          (setq-local gptel--known-presets (buffer-local-value 'gptel--known-presets parent)))
-        (if (boundp 'gptel-directives)
-            (setq gptel-directives (buffer-local-value 'gptel-directives parent))
-          (setq-local gptel-directives (buffer-local-value 'gptel-directives parent))))
+        (setq-local gptel--known-presets (buffer-local-value 'gptel--known-presets parent))
+        (setq-local gptel-directives (buffer-local-value 'gptel-directives parent)))
 
       (when-let* ((c-ctx cloned-ctx))
         (setq-local macher-agent--persistent-context c-ctx))

--- a/macher-agent-presets.el
+++ b/macher-agent-presets.el
@@ -118,8 +118,12 @@ Return a property list containing skill properties.
 Side effects: Reads file or VFS buffer into a temporary buffer."
   (cl-assert (stringp filepath) nil "FILEPATH must be a string, got: %S" filepath)
   (let* ((resolved-ctx (cond
-                        ((macher-agent-valid-context-p context) context)
-                        (context (macher-agent-resolve-context context))
+                        ((or (macher-agent-context-p context) (macher-agent-valid-context-p context))
+                         context)
+                        ((or (bufferp context) (stringp context))
+                         (macher-agent-context-from-buffer context))
+                        ((macher-agent-transit-payload-p context)
+                         (macher-agent-context-from-payload context))
                         (t (bound-and-true-p macher-agent--persistent-context))))
          (workspace-root (when resolved-ctx (macher-agent-context-workspace-root resolved-ctx)))
          (abs-file (expand-file-name filepath))

--- a/macher-agent-sandbox.el
+++ b/macher-agent-sandbox.el
@@ -21,7 +21,6 @@
 (require 'macher-agent-tools)
 
 (declare-function cps-internal-yield "generator")
-(declare-function gptel-fsm-info "gptel" (fsm))
 (declare-function gptel-tool-p "gptel" (tool))
 (declare-function gptel-tool-name "gptel" (tool))
 (declare-function gptel-tool-description "gptel" (tool))
@@ -68,15 +67,8 @@ Return t if SYM is an active primitive, otherwise nil.
 Side effects: None."
   (let* ((sym-name (symbol-name sym))
          (norm-sym (replace-regexp-in-string "_" "-" sym-name))
-
-         (fsm-obj (macher-agent-get-active-fsm))
-         (info (when fsm-obj (macher-agent--extract-fsm-info fsm-obj)))
-
-         (active (or (when (macher-agent--plist-p info) (plist-get info :ptc-primitives))
-                     (bound-and-true-p macher-agent--active-ptc-primitives)))
-         (tools (or (when (macher-agent--plist-p info) (plist-get info :tools))
-                    (bound-and-true-p gptel-tools))))
-
+         (active (bound-and-true-p macher-agent--active-ptc-primitives))
+         (tools (bound-and-true-p gptel-tools)))
     (and (or (memq sym active)
              (cl-some (lambda (prim)
                         (let* ((prim-name (if (symbolp prim) (symbol-name prim) prim))
@@ -182,12 +174,12 @@ Including a number of hardcoded defaults."
 (iter-defun macher-agent-sandbox--funcall-iter (func eval-args)
             "Execute function FUNC with EVAL-ARGS in the sandbox."
             (cond
-             ((and (consp func) (eq (car func) 'closure))
-              (iter-yield-from (macher-agent-sandbox--apply-closure-iter func eval-args)))
              ((and (consp func) (eq (car func) 'lambda))
               (iter-yield-from
                (macher-agent-sandbox--apply-closure-iter
                 (list 'closure (cadr func) (cddr func) nil) eval-args)))
+             ((and (consp func) (eq (car func) 'closure))
+              (iter-yield-from (macher-agent-sandbox--apply-closure-iter func eval-args)))
              ((symbolp func)
               (iter-yield-from (macher-agent-sandbox--funcall-symbol-iter func eval-args)))
              (t (error "Invalid function target: %s" func))))
@@ -807,26 +799,21 @@ Side effects: None."
           (macher-agent--coerce-plist-args args schema)
         (macher-agent--coerce-positional-args args schema)))))
 
-(defun macher-agent--display-ptc-tool-execution (tool-sym args context)
+(defun macher-agent--display-ptc-tool-execution (tool-sym args context target-buf)
   "Display mode-line status and run pre-execution hooks for PTC tool.
 
 TOOL-SYM is the symbol name of the target PTC tool.
 ARGS is the list of arguments supplied to the tool call.
 CONTEXT is the active agent context structure.
+TARGET-BUF is the target buffer for tool execution.
 
 Return cons cell of (ORIGINAL-NAME-STRING . RESOLVED-TOOL).
 Side effects: Updates mode-line status and executes pre-tool-call hooks."
   (let* ((target-lisp-name (symbol-name tool-sym))
          (original-name-str (replace-regexp-in-string "-" "_" target-lisp-name))
-         (fsm (macher-agent-get-active-fsm))
-         (fsm-info (when fsm (macher-agent--extract-fsm-info fsm)))
-         (fsm-ctx (when (macher-agent--plist-p fsm-info)
-                    (plist-get fsm-info :macher-agent-context)))
-         (ctx (or (when (macher-agent-valid-context-p context) context)
-                  fsm-ctx
-                  (bound-and-true-p macher-agent--persistent-context)))
+         (tool-name original-name-str)
          (resolved-tool (if (fboundp 'macher-agent-resolve-tool)
-                            (macher-agent-resolve-tool original-name-str nil nil ctx)
+                            (macher-agent-resolve-tool original-name-str nil nil context)
                           (when (and (boundp 'macher-agent-tools-registry)
                                      (hash-table-p macher-agent-tools-registry))
                             (gethash original-name-str macher-agent-tools-registry))))
@@ -841,7 +828,8 @@ Side effects: Updates mode-line status and executes pre-tool-call hooks."
        (lambda (f)
          (let ((res (ignore-errors
                       (funcall f (list :name original-name-str :args args
-                                       :buffer (buffer-name) :model (bound-and-true-p gptel-model))))))
+                                       :buffer (buffer-name (if (bufferp target-buf) target-buf (current-buffer)))
+                                       :model (bound-and-true-p gptel-model))))))
            (when (and res (listp res) (plist-get res :block))
              (setq block-reason (plist-get res :block))
              t)))))
@@ -849,20 +837,8 @@ Side effects: Updates mode-line status and executes pre-tool-call hooks."
     (if block-reason
         (error "%s" block-reason)
       (message "PTC Executing: %s" (or desc original-name-str))
-
-      (when-let* (((fboundp 'gptel--update-tool-call))
-                  (fsm-obj (macher-agent-get-active-fsm))
-                  (info (macher-agent--extract-fsm-info fsm-obj))
-                  (mock-info (plist-put (copy-sequence info)
-                                        :tool-use
-                                        (list (list :name (format "PTC: %s" tool-sym))))))
-
-        (unwind-protect
-            (progn
-              (macher-agent--set-fsm-info fsm-obj mock-info)
-              (gptel--update-tool-call fsm-obj))
-          (macher-agent--set-fsm-info fsm-obj info)))
-
+      (when (fboundp 'macher-agent-gptel-spoof-tool-ui)
+        (macher-agent-gptel-spoof-tool-ui target-buf tool-name))
       (cons original-name-str resolved-tool))))
 
 (defun macher-agent--format-ptc-result-block (truncated-call call-str str-res)
@@ -923,7 +899,7 @@ Side effects: Inserts formatted result block text into buffer at buffer max."
           (macher-agent--cycle-ptc-result-block))))))
 
 (defun macher-agent--dispatch-ptc-primitive
-    (tool-lisp-sym args resolved-tool original-name-str ptc-callback on-error stop-iter-fn)
+    (tool-lisp-sym args resolved-tool original-name-str ptc-callback on-error stop-iter-fn &optional target-buf context)
   "Dispatch TOOL-LISP-SYM with ARGS or RESOLVED-TOOL for ORIGINAL-NAME-STR.
 
 TOOL-LISP-SYM is the symbol of the tool function.
@@ -933,47 +909,62 @@ ORIGINAL-NAME-STR is the string name of the original tool.
 PTC-CALLBACK is the callback function upon successful execution.
 ON-ERROR is the callback function invoked upon error.
 STOP-ITER-FN is the function to halt the iterator.
+TARGET-BUF is the target buffer for tool execution.
+CONTEXT is the active agent context structure.
 
 Return result of dispatching tool execution.
 Side effects: Invokes tool function and callbacks."
-  (cond
-   ((and (macher-tool-valid-p resolved-tool)
-         (gptel-tool-function resolved-tool))
-    (let ((coerced-args (macher-agent--coerce-ptc-args args resolved-tool)))
-      (if (gptel-tool-async resolved-tool)
-          (let ((called nil))
-            (apply (gptel-tool-function resolved-tool)
-                   (lambda (res &optional err)
-                     (unless called
-                       (setq called t)
-                       (if err
-                           (funcall stop-iter-fn err)
-                         (funcall ptc-callback res))))
-                   coerced-args))
-        (let ((sync-result (apply (gptel-tool-function resolved-tool) coerced-args)))
-          (funcall ptc-callback sync-result)))))
-   ((and (symbolp tool-lisp-sym)
-         (fboundp tool-lisp-sym)
-         (or (macher-agent--ptc-primitive-p tool-lisp-sym)
-             (and (boundp 'macher-agent-sandbox--primitives)
-                  (hash-table-p macher-agent-sandbox--primitives)
-                  (gethash tool-lisp-sym macher-agent-sandbox--primitives))
-             (and (boundp 'macher-agent-allowed-tools)
-                  (listp macher-agent-allowed-tools)
-                  (memq tool-lisp-sym macher-agent-allowed-tools))))
-    (let ((lisp-res (apply tool-lisp-sym args)))
-      (funcall ptc-callback lisp-res)))
-   (t
-    (when stop-iter-fn (funcall stop-iter-fn "Tool not accessible"))
-    (funcall on-error
-             (list :status 'error
-                   :error (format "ERROR: Tool '%s' is not accessible." original-name-str))))))
+  (let ((run-in-target
+         (lambda (fn)
+           (if (and target-buf (buffer-live-p target-buf))
+               (with-current-buffer target-buf
+                 (when (and context (macher-agent-valid-context-p context))
+                   (setq macher-agent--persistent-context context))
+                 (funcall fn))
+             (funcall fn)))))
+    (cond
+     ((and (macher-tool-valid-p resolved-tool)
+           (gptel-tool-function resolved-tool))
+      (let ((coerced-args (macher-agent--coerce-ptc-args args resolved-tool)))
+        (funcall run-in-target
+                 (lambda ()
+                   (if (gptel-tool-async resolved-tool)
+                       (let ((called nil))
+                         (apply (gptel-tool-function resolved-tool)
+                                (lambda (res &optional err)
+                                  (unless called
+                                    (setq called t)
+                                    (if err
+                                        (funcall stop-iter-fn err)
+                                      (funcall ptc-callback res))))
+                                coerced-args))
+                     (let ((sync-result (apply (gptel-tool-function resolved-tool) coerced-args)))
+                       (funcall ptc-callback sync-result)))))))
+     ((and (symbolp tool-lisp-sym)
+           (fboundp tool-lisp-sym)
+           (or (macher-agent--ptc-primitive-p tool-lisp-sym)
+               (and (boundp 'macher-agent-sandbox--primitives)
+                    (hash-table-p macher-agent-sandbox--primitives)
+                    (gethash tool-lisp-sym macher-agent-sandbox--primitives))
+               (and (boundp 'macher-agent-allowed-tools)
+                    (listp macher-agent-allowed-tools)
+                    (memq tool-lisp-sym macher-agent-allowed-tools))))
+      (funcall run-in-target
+               (lambda ()
+                 (let ((lisp-res (apply tool-lisp-sym args)))
+                   (funcall ptc-callback lisp-res)))))
+     (t
+      (when stop-iter-fn (funcall stop-iter-fn "Tool not accessible"))
+      (funcall on-error
+               (list :status 'error
+                     :error (format "ERROR: Tool '%s' is not accessible." original-name-str)))))))
 
-(defun macher-agent--ptc-handle-yielded-value (yielded-val context ptc-resume-loop on-error stop-iter-fn)
+(defun macher-agent--ptc-handle-yielded-value (yielded-val context target-buf ptc-resume-loop on-error stop-iter-fn)
   "Handle YIELDED-VAL returned during PTC execution.
 
 YIELDED-VAL is the value yielded from sandbox evaluation iterator.
 CONTEXT is the active agent context structure.
+TARGET-BUF is the target buffer for tool execution.
 PTC-RESUME-LOOP is the loop continuation callback function.
 ON-ERROR is the error callback function on failure.
 STOP-ITER-FN is the callback function halting iterator.
@@ -983,14 +974,7 @@ Side effects: Triggers tool execution and schedules loop resumption."
   (if (and (macher-agent-tool-call-p yielded-val) (macher-agent-tool-call-name yielded-val))
       (let* ((tool-lisp-sym (macher-agent-tool-call-name yielded-val))
              (args (macher-agent-tool-call-args yielded-val))
-             (fsm (macher-agent-get-active-fsm))
-             (fsm-info (when fsm (macher-agent--extract-fsm-info fsm)))
-             (fsm-ctx (when (macher-agent--plist-p fsm-info)
-                        (plist-get fsm-info :macher-agent-context)))
-             (ctx (or (when (macher-agent-valid-context-p context) context)
-                      fsm-ctx
-                      (bound-and-true-p macher-agent--persistent-context)))
-             (tool-info (macher-agent--display-ptc-tool-execution tool-lisp-sym args ctx))
+             (tool-info (macher-agent--display-ptc-tool-execution tool-lisp-sym args context target-buf))
              (original-name-str (car tool-info))
              (resolved-tool (cdr tool-info))
              (ptc-callback (lambda (res-data)
@@ -998,114 +982,79 @@ Side effects: Triggers tool execution and schedules loop resumption."
                              (funcall ptc-resume-loop res-data))))
         (macher-agent--dispatch-ptc-primitive
          tool-lisp-sym args resolved-tool original-name-str
-         ptc-callback on-error stop-iter-fn))
+         ptc-callback on-error stop-iter-fn target-buf context))
     (let ((reason (format "Unexpected yield from PTC sandbox: %S" yielded-val)))
       (when stop-iter-fn (funcall stop-iter-fn reason))
       (funcall on-error (list :status 'error :error reason)))))
 
 (defun macher-agent-execute-ptc-script
-    (script-string context on-success on-error &optional extra-primitives target-buf)
-  "Execute Programmatic Tool Calling SCRIPT-STRING using CONTEXT.
+    (script-string context target-buf on-success on-error &optional extra-primitives)
+  "Execute Programmatic Tool Calling SCRIPT-STRING using CONTEXT in TARGET-BUF.
 
 SCRIPT-STRING is the string containing Lisp code to evaluate.
-CONTEXT is the active VFS context structure.
+CONTEXT is the active context structure.
+TARGET-BUF is the target buffer for execution.
 ON-SUCCESS is the callback function invoked with success result.
 ON-ERROR is the callback function invoked with error result.
-EXTRA-PRIMITIVES is an optional list of allowed primitive functions.
-TARGET-BUF is an optional target buffer for execution.
+EXTRA-PRIMITIVES is an optional list of allowed primitive host functions.
 
 Return nil.
 Side effects: Evaluates Lisp code in a sandboxed environment."
-  (let* ((prims (or extra-primitives
-                    '(nreverse sort delete delq nconc plist-put aset puthash remhash error signal message random emacs-version)))
-         (buf (or target-buf (current-buffer)))
-         (active-fsm (macher-agent-get-active-fsm))
-         (fsm-info (when active-fsm (macher-agent--extract-fsm-info active-fsm)))
-         (fsm-ctx (when (macher-agent--plist-p fsm-info)
-                    (plist-get fsm-info :macher-agent-context)))
-         (resolved-ctx (or (when (macher-agent-valid-context-p context) context)
-                           fsm-ctx
-                           (when (and buf (buffer-live-p buf))
-                             (let ((bctx (buffer-local-value 'macher-agent--persistent-context buf)))
-                               (when (macher-agent-valid-context-p bctx) bctx)))
-                           (when (and (bound-and-true-p macher-agent--persistent-context)
-                                      (macher-agent-valid-context-p macher-agent--persistent-context))
-                             macher-agent--persistent-context)
-                           (when context
-                             (macher-agent-resolve-context context))
-                           (macher-agent-resolve-context))))
-    (let ((macher-agent--active-ptc-execution t))
-      (condition-case err
-          (progn
-            (with-current-buffer buf
-              (when resolved-ctx
-                (setq-local macher-agent--persistent-context resolved-ctx))
-              (when (and active-fsm resolved-ctx (fboundp 'macher-agent--inject-context-into-fsm-info))
-                (macher-agent--inject-context-into-fsm-info resolved-ctx active-fsm))
-              (when (boundp 'macher-agent-sandbox--globals)
-                (setq macher-agent-sandbox--globals (make-hash-table :test 'eq)))
-              (when (boundp 'macher-agent-sandbox--primitives)
-                (setq macher-agent-sandbox--primitives (make-hash-table :test 'eq)))
-              (when (boundp 'macher-agent-sandbox--functions)
-                (setq macher-agent-sandbox--functions (make-hash-table :test 'eq)))
-              (macher-agent-sandbox--init prims))
-            (let* ((ast (macroexpand-all (let ((read-eval nil))
-                                           (read (format "(progn\n%s\n)" script-string)))))
-                   (iterator (with-current-buffer buf
-                               (macher-agent-sandbox--eval-iter ast nil)))
-                   (stop-iter-fn (lambda (reason)
-                                   (funcall on-error (list :status 'error :error reason)))))
-              (letrec
-                  ((ptc-resume-loop
-                    (lambda (input)
-                      (condition-case iter-err
-                          (let ((step (with-current-buffer buf (iter-next iterator input))))
-                            (if (macher-agent-tool-call-p step)
-                                (macher-agent--ptc-handle-yielded-value
-                                 step resolved-ctx ptc-resume-loop on-error stop-iter-fn)
-                              (funcall ptc-resume-loop step)))
-                        (iter-end-of-sequence
-                         (funcall on-success (cdr iter-err)))
-                        (error
-                         (funcall on-error (list :status 'error :error (error-message-string iter-err))))))))
-                (funcall ptc-resume-loop nil))))
-        (error
-         (funcall on-error (list :status 'error :error (error-message-string err))))))))
+  (let* ((prims (append
+                 '(nreverse sort delete delq nconc plist-put aset puthash remhash error signal message random emacs-version)
+                 extra-primitives))
+         (macher-agent--active-ptc-execution t))
+    (condition-case err
+        (progn
+          (with-current-buffer target-buf
+            (setq macher-agent--persistent-context context)
+            (when (boundp 'macher-agent-sandbox--globals)
+              (setq macher-agent-sandbox--globals (make-hash-table :test 'eq)))
+            (when (boundp 'macher-agent-sandbox--primitives)
+              (setq macher-agent-sandbox--primitives (make-hash-table :test 'eq)))
+            (when (boundp 'macher-agent-sandbox--functions)
+              (setq macher-agent-sandbox--functions (make-hash-table :test 'eq)))
+            (macher-agent-sandbox--init prims))
+          (let* ((ast (macroexpand-all (let ((read-eval nil))
+                                         (read (format "(progn\n%s\n)" script-string)))))
+                 (iterator (with-current-buffer target-buf
+                             (macher-agent-sandbox--eval-iter ast nil)))
+                 (stop-iter-fn (lambda (reason)
+                                 (funcall on-error (list :status 'error :error reason)))))
+            (letrec
+                ((ptc-resume-loop
+                  (lambda (input)
+                    (condition-case iter-err
+                        (let ((step (with-current-buffer target-buf (iter-next iterator input))))
+                          (if (macher-agent-tool-call-p step)
+                              (macher-agent--ptc-handle-yielded-value
+                               step context target-buf ptc-resume-loop on-error stop-iter-fn)
+                            (funcall ptc-resume-loop step)))
+                      (iter-end-of-sequence
+                       (funcall on-success (cdr iter-err)))
+                      (error
+                       (funcall on-error (list :status 'error :error (error-message-string iter-err))))))))
+              (funcall ptc-resume-loop nil))))
+      (error
+       (funcall on-error (list :status 'error :error (error-message-string err)))))))
 
-(defun macher-agent-sandbox-run (expression extra-operations &optional context)
+(defun macher-agent-sandbox-run (expression extra-operations context target-buf)
   "Execute Lisp EXPRESSION in a sandboxed environment with EXTRA-OPERATIONS.
 
 EXPRESSION is the Lisp expression form to evaluate inside sandbox.
 EXTRA-OPERATIONS is a list of host function symbols allowed in sandbox.
-CONTEXT is an optional context structure to use for logging tool intent.
+CONTEXT is the active agent context structure to use for logging tool intent.
+TARGET-BUF is the target buffer of the execution.
 
 Return the result of evaluating EXPRESSION.
 
 Side effects: Evaluates sandboxed Lisp expression."
-  (declare (ftype (function (t list &optional t) t)))
+  (declare (ftype (function (t list t t) t)))
   (let ((macher-agent-sandbox--primitives (make-hash-table :test 'eq))
         (macher-agent-sandbox--functions (make-hash-table :test 'eq))
         (macher-agent-sandbox--globals (make-hash-table :test 'eq)))
-    (when (fboundp 'macher-agent-sandbox--init)
-      (macher-agent-sandbox--init extra-operations))
-    (let* ((active-fsm (macher-agent-get-active-fsm))
-           (fsm-info (when active-fsm (macher-agent--extract-fsm-info active-fsm)))
-           (fsm-ctx (when (macher-agent--plist-p fsm-info)
-                      (plist-get fsm-info :macher-agent-context)))
-           (ctx (or (when (macher-agent-valid-context-p context) context)
-                    fsm-ctx
-                    (when (and (bound-and-true-p macher-agent--persistent-context)
-                               (macher-agent-valid-context-p macher-agent--persistent-context))
-                      macher-agent--persistent-context)
-                    (when (buffer-live-p (current-buffer))
-                      (let ((bctx (buffer-local-value 'macher-agent--persistent-context (current-buffer))))
-                        (when (macher-agent-valid-context-p bctx) bctx)))))
-           (ctx (or ctx
-                    (when context
-                      (macher-agent-resolve-context context))
-                    (macher-agent-resolve-context)))
-           (iterator (when (fboundp 'macher-agent-sandbox--eval-iter)
-                       (macher-agent-sandbox--eval-iter (macroexpand-all expression) nil)))
+    (macher-agent-sandbox--init extra-operations)
+    (let* ((iterator (macher-agent-sandbox--eval-iter (macroexpand-all expression) nil))
            (yield-val nil)
            (next-yield nil))
       (if (null iterator)
@@ -1125,9 +1074,9 @@ Side effects: Evaluates sandboxed Lisp expression."
                 (when (and tc (macher-agent-tool-call-name tc))
                   (let ((target (macher-agent-tool-call-name tc))
                         (args (macher-agent-tool-call-args tc)))
-                    (when (and ctx target)
+                    (when (and context target)
                       (when (fboundp 'macher-agent-log-tool-intent)
-                        (macher-agent-log-tool-intent ctx "ptc" target args))))))
+                        (macher-agent-log-tool-intent context "ptc" target args))))))
               (setq yield-val next-yield))
           (iter-end-of-sequence (cdr err)))))))
 
@@ -1157,36 +1106,13 @@ Side effects: Evaluates sandboxed Lisp expression."
 (defun macher-agent-sandbox-install ()
   "Install Programmatic Tool Calling hooks, tools, and pipeline steps."
   (macher-agent-register-pipeline-step 'preset-composition #'macher-agent-ptc--inject-tool 50)
-  (macher-agent-register-pipeline-step 'transmission #'macher-agent-sandbox-append-ptc-directive 80)
-  (unless (and (bound-and-true-p macher-agent-ptc-execution-tool)
-               (macher-tool-valid-p macher-agent-ptc-execution-tool))
-    (macher-agent-make-tool
-     macher-agent-ptc-execution-tool
-     "Execute an Emacs Lisp orchestration script. Use this to orchestrate multiple tools, spawn sub-agents, and handle complex asynchronous workflows in a single step."
-     :category "execution"
-     :include nil
-     :args
-     '((:name "script"
-              :type string
-              :description "The Emacs Lisp script to execute. Use standard let*, mapcar, dolist, and permitted tool primitives."))
-     :command-fn
-     (lambda (payload context _root callback)
-       (if-let* ((script (plist-get payload :script)))
-           (macher-agent-execute-ptc-script
-            script context
-            (lambda (res) (funcall callback res))
-            (lambda (err) (funcall callback err)))
-         (error "No script provided for PTC execution"))))))
+  (macher-agent-register-pipeline-step 'transmission #'macher-agent-sandbox-append-ptc-directive 80))
 
 (defun macher-agent-sandbox-uninstall ()
   "Uninstall Programmatic Tool Calling hooks, tools, and pipeline steps."
   (macher-agent-unregister-pipeline-step 'preset-composition #'macher-agent-ptc--inject-tool)
   (macher-agent-unregister-pipeline-step 'transmission #'macher-agent-sandbox-append-ptc-directive)
-  (setq macher-agent-ptc-execution-tool nil)
-  (when (boundp 'gptel--known-tools)
-    (when-let* ((exec-alist (alist-get "execution" gptel--known-tools nil nil #'equal)))
-      (setf (alist-get "execution" gptel--known-tools nil nil #'equal)
-            (assoc-delete-all "ptc_execution" exec-alist #'equal)))))
+  (setq macher-agent-ptc-execution-tool nil))
 
 (provide 'macher-agent-sandbox)
 ;;; macher-agent-sandbox.el ends here

--- a/macher-agent-tools.el
+++ b/macher-agent-tools.el
@@ -131,7 +131,7 @@ Side effects: Signals error if missing required properties or invalid types."
     (when (and (consp reqs) (eq (car reqs) 'quote)) (setq reqs (cadr reqs)))
     (when (vectorp reqs) (setq reqs (append reqs nil)))
     (when props
-      (unless (and (listp props) (evenp (length props)))
+      (unless (and (listp props) (cl-evenp (length props)))
         (error "%s" (format
                      "Schema properties for '%s' must be a flat plist, got %S" name props)))
       (cl-loop
@@ -242,7 +242,7 @@ Side effects: None."
                       val)
               (setq result (plist-put result under-key val))
               (setq result (plist-put result hyphen-key val)))))
-        (when (and (listp raw-plist) (evenp (length raw-plist)))
+        (when (and (listp raw-plist) (cl-evenp (length raw-plist)))
           (cl-loop for (k v) on raw-plist by #'cddr
                    do (unless (plist-member result k)
                         (setq result (plist-put result k v)))))
@@ -388,29 +388,16 @@ Side effects: Sets `NAME-SYMBOL' variable to constructed gptel tool object."
                    ',name-symbol (macher-agent-tool-call-args tool-call) wrap-cb
                    (macher-agent--validate-payload (macher-agent-tool-call-args tool-call) ,args)
                    (let*
-                       ((fsm (macher-agent-get-active-fsm))
-                        (fsm-info (when fsm (macher-agent--extract-fsm-info fsm)))
-                        (origin-buf (when (macher-agent--plist-p fsm-info)
-                                      (or (plist-get fsm-info :origin-buffer)
-                                          (plist-get fsm-info :buffer))))
-                        (context
+                       ((context
                          (or incoming-ctx
-                             (when (macher-agent--plist-p fsm-info)
-                               (let ((f-ctx (plist-get fsm-info :macher-agent-context)))
-                                 (when (macher-agent-valid-context-p f-ctx)
-                                   f-ctx)))
-                             (when fsm
-                               (macher-agent-resolve-context fsm))
-                             (when (and origin-buf (buffer-live-p origin-buf))
-                               (let ((buf-ctx (buffer-local-value 'macher-agent--persistent-context origin-buf)))
-                                 (if (macher-agent-valid-context-p buf-ctx)
-                                     buf-ctx
-                                   (macher-agent-resolve-context origin-buf))))
+                             (macher-agent-gptel-context-from-fsm (macher-agent-get-active-fsm))
                              (when (bound-and-true-p macher-agent--persistent-context)
                                (when (macher-agent-valid-context-p macher-agent--persistent-context)
                                  macher-agent--persistent-context))
-                             (macher-agent-resolve-context (current-buffer))
-                             (macher-agent-resolve-context)))
+                             (when (buffer-live-p (current-buffer))
+                               (let ((buf-ctx (buffer-local-value 'macher-agent--persistent-context (current-buffer))))
+                                 (when (macher-agent-valid-context-p buf-ctx)
+                                   buf-ctx)))))
                         (root
                          (if context
                              (macher-agent-context-root context)

--- a/macher-agent-vfs.el
+++ b/macher-agent-vfs.el
@@ -12,8 +12,6 @@
 (require 'macher-agent-core)
 (require 'macher-agent-macher)
 
-(declare-function gptel-fsm-info "gptel" (fsm))
-(declare-function gptel-fsm-p "gptel" (obj))
 (declare-function mailcap-file-name-to-mime-type "mailcap" (file-name))
 
 (defvar macher-agent--vfs-lock-table (make-hash-table :test 'equal)
@@ -927,8 +925,8 @@ Side effects: May update CTX dirty state and persist state if synced."
 (defmacro macher-agent-with-vfs-scope (context &rest body)
   "Execute BODY with Virtual File System awareness established from CONTEXT.
 
-CONTEXT is the context structure, state machine, buffer environment,
-or workspace to resolve.  When nil, attempts to resolve from the environment.
+CONTEXT is the context structure or buffer environment to resolve.
+When nil, attempts to resolve from the environment.
 BODY is the sequence of forms to evaluate within the established VFS scope.
 
 Fails fast by signaling an error if the context cannot be resolved.
@@ -944,9 +942,10 @@ Side effects: Binds `macher-agent--persistent-context' and adjusts `default-dire
             (,ctx-sym (cond
                        ((and ,raw-ctx-sym (macher-agent-valid-context-p ,raw-ctx-sym))
                         ,raw-ctx-sym)
-                       (,raw-ctx-sym
-                        (macher-agent-resolve-context ,raw-ctx-sym))
-                       (t (macher-agent-resolve-context)))))
+                       ((and (bound-and-true-p macher-agent--persistent-context)
+                             (macher-agent-valid-context-p macher-agent--persistent-context))
+                        macher-agent--persistent-context)
+                       (t nil))))
        (unless (and ,ctx-sym (macher-agent-valid-context-p ,ctx-sym))
          (error "macher-agent-with-vfs-scope: Unable to resolve a valid VFS context from %S" ,raw-ctx-sym))
        (let* ((macher-agent--persistent-context ,ctx-sym)
@@ -991,27 +990,20 @@ Side effects: None."
           (format "*macher-%s-patch[%s]*" category buf-name)
         (format "*macher-%s-patch*" category)))))
 
-(defun macher-agent--build-and-rename-patch (ctx fsm-obj patch-type)
-  "Build patch for CTX using FSM-OBJ, reusing and renaming buffers deterministically.
+(defun macher-agent--build-and-rename-patch (ctx patch-type &optional files)
+  "Build patch for CTX, reusing and renaming buffers deterministically.
 
-Construct a patch buffer for context CTX and finite-state machine FSM-OBJ if
-CTX contains changes and patch generation is not suppressed.  Renames the
-newly built patch buffer directly in place to the expressive patch buffer name
-so that the patch buffer remains live and retains its identity.
+Construct a patch buffer for context CTX if CTX contains changes and patch
+generation is not suppressed.  Renames the newly built patch buffer directly in
+place to the expressive patch buffer name so that the patch buffer remains live
+and retains its identity.
 
 Return the renamed patch buffer if generated, or nil.
 
 Side effects: Reuses, modifies, and renames patch buffers."
-  (let* ((target-buf (or (when (and fsm-obj (fboundp 'gptel-fsm-info) (fboundp 'gptel-fsm-p) (gptel-fsm-p fsm-obj))
-                           (plist-get (gptel-fsm-info fsm-obj) :buffer))
-                         (when (and fsm-obj (macher-agent--plist-p fsm-obj))
-                           (plist-get fsm-obj :buffer))
-                         (when (macher-agent-valid-context-p ctx)
-                           (or (macher-agent-vfs--get-origin-buffer ctx)
-                               (macher-agent-context-origin-buffer ctx)))
-                         (when-let* ((active-fsm (macher-agent-get-active-fsm fsm-obj)))
-                           (when (and (fboundp 'gptel-fsm-info) (fboundp 'gptel-fsm-p) (gptel-fsm-p active-fsm))
-                             (plist-get (gptel-fsm-info active-fsm) :buffer)))))
+  (let* ((target-buf (when (macher-agent-valid-context-p ctx)
+                       (or (macher-agent-vfs--get-origin-buffer ctx)
+                           (macher-agent-context-origin-buffer ctx))))
          (suppress-patch (if (and (bufferp target-buf) (buffer-live-p target-buf))
                              (buffer-local-value 'macher-agent--suppress-patch target-buf)
                            (bound-and-true-p macher-agent--suppress-patch)))
@@ -1020,7 +1012,7 @@ Side effects: Reuses, modifies, and renames patch buffers."
     (when (and (not suppress-patch)
                (macher-agent--context-has-changes-p ctx))
       (let* ((expressive-name (macher-agent--expressive-patch-buffer-name patch-type ws target-buf))
-             (patch-buf (macher-agent-macher-build-patch ctx fsm-obj)))
+             (patch-buf (macher-agent-macher-build-patch ctx (or (macher-agent-context-prompt ctx) "") files)))
         (if (and patch-buf (buffer-live-p patch-buf))
             (if (equal (buffer-name patch-buf) expressive-name)
                 patch-buf
@@ -1095,17 +1087,14 @@ Return a cons cell of cloned contexts (FILE-CONTEXT . BUFFER-CONTEXT)."
     (when buf-ctx (macher-agent--set-context-contents buf-ctx buf-contents))
     (cons file-ctx buf-ctx)))
 
-(defun macher-agent--execute-split-patch (ctx fsm-obj)
-  "Execute the split patch generation for physical and virtual contexts."
+(defun macher-agent--execute-split-patch (ctx)
+  "Execute the split patch generation for physical and virtual contexts in CTX."
   (when (or (macher-agent--get-context-dirty-p ctx)
             (macher-agent--context-has-changes-p ctx))
     (let* ((payloads (macher-agent--split-context ctx))
            (p-ctx (car payloads))
            (v-ctx (cdr payloads))
-           (prompt (or (and (fboundp 'gptel-fsm-info) (fboundp 'gptel-fsm-p) fsm-obj (gptel-fsm-p fsm-obj) (plist-get (gptel-fsm-info fsm-obj) :prompt))
-                       (and (listp fsm-obj) (plist-get fsm-obj :prompt))
-                       (when (macher-agent-context-p ctx) (macher-agent-context-prompt ctx))
-                       ""))
+           (prompt (or (when (macher-agent-context-p ctx) (macher-agent-context-prompt ctx)) ""))
            (generated-buffers nil))
       (when prompt
         (when p-ctx
@@ -1118,42 +1107,41 @@ Return a cons cell of cloned contexts (FILE-CONTEXT . BUFFER-CONTEXT)."
             (setf (macher-agent-context-prompt v-ctx) prompt)
             (setf (macher-agent-context-plugins v-ctx)
                   (plist-put (copy-sequence (macher-agent-context-plugins v-ctx)) :prompt prompt)))))
-      (when-let* ((p-buf (macher-agent--build-and-rename-patch p-ctx fsm-obj "physical")))
+      (when-let* ((p-buf (macher-agent--build-and-rename-patch p-ctx "physical")))
         (push p-buf generated-buffers))
-      (when-let* ((v-buf (macher-agent--build-and-rename-patch v-ctx fsm-obj "virtual")))
+      (when-let* ((v-buf (macher-agent--build-and-rename-patch v-ctx "virtual")))
         (push v-buf generated-buffers))
       (when generated-buffers
         (macher-agent--display-patch-buffers generated-buffers)))
     (macher-agent--set-context-dirty-p ctx nil)))
 
 (defun macher-agent-vfs-build-patch-from-hook (ctx)
-  "Observe VFS flush events and build the visual macher interface."
+  "Observe VFS flush events and build the visual macher interface for CTX."
   (when (macher-agent-valid-context-p ctx)
-    (let* ((fsm-obj (macher-agent-get-active-fsm))
-           (prompt (or (and (fboundp 'gptel-fsm-info) (fboundp 'gptel-fsm-p) fsm-obj (gptel-fsm-p fsm-obj) (plist-get (gptel-fsm-info fsm-obj) :prompt))
-                       (and (listp fsm-obj) (plist-get fsm-obj :prompt))
-                       (when (macher-agent-context-p ctx) (macher-agent-context-prompt ctx))
-                       "")))
+    (let ((prompt (or (when (macher-agent-context-p ctx) (macher-agent-context-prompt ctx)) "")))
       (when prompt
         (when (macher-agent-context-p ctx)
           (setf (macher-agent-context-prompt ctx) prompt)
           (setf (macher-agent-context-plugins ctx)
                 (plist-put (copy-sequence (macher-agent-context-plugins ctx)) :prompt prompt))))
-      (macher-agent--execute-split-patch ctx fsm-obj))))
+      (macher-agent--execute-split-patch ctx))))
 
 (defun macher-agent-vfs-diff-review (&optional ctx)
   "Review pending diff patches for uncommitted VFS modifications in CTX.
 
-When CTX is nil, resolves context from the current environment or active buffer.
+When CTX is nil, resolves context from the active persistent context.
 Subscribes to or dispatches through `macher-agent-vfs-handle-flush'.
 
 Return nil.
 Side effects: Displays generated patch review buffers for pending edits."
   (interactive)
   (let ((context (or (when (macher-agent-valid-context-p ctx) ctx)
-                     (bound-and-true-p macher-agent--persistent-context)
-                     (ignore-errors (macher-agent-resolve-context (current-buffer)))
-                     (ignore-errors (macher-agent-resolve-context)))))
+                     (when (bound-and-true-p macher-agent--persistent-context)
+                       (and (macher-agent-valid-context-p macher-agent--persistent-context)
+                            macher-agent--persistent-context))
+                     (let ((buf-ctx (buffer-local-value 'macher-agent--persistent-context (current-buffer))))
+                       (when (macher-agent-valid-context-p buf-ctx)
+                         buf-ctx)))))
     (if (and context (macher-agent-valid-context-p context))
         (macher-agent-vfs-handle-flush context)
       (message "No active VFS context found."))))
@@ -1202,7 +1190,7 @@ Support polymorphic invocation:
 - (macher-agent-vfs--merge-payload payload)
 - (macher-agent-vfs--merge-payload target payload)
 
-TARGET can be `gptel-fsm', `macher-agent-context', or a buffer/FSM container.
+TARGET can be `macher-agent-context', a buffer, or a transit payload.
 PAYLOAD is the property list, struct, or list of diff entries containing merge artifacts.
 
 Exhaustively extracts target context from PAYLOAD keys (`macher-agent-transit-context-keys'),
@@ -1235,36 +1223,26 @@ Return updated PAYLOAD or context."
                 (cond
                  ((macher-agent-valid-context-p target)
                   target)
-                 ((and (fboundp 'gptel-fsm-p) (gptel-fsm-p target))
-                  (or (macher-agent-gptel--fsm-context target)
-                      (macher-agent--extract-fsm-context target)
-                      (let* ((info (macher-agent--extract-fsm-info target))
-                             (buf (when (macher-agent--plist-p info) (plist-get info :buffer))))
-                        (when buf (macher-agent-resolve-context buf)))))
-                 ((and (recordp target) (fboundp 'gptel-fsm-p) (gptel-fsm-p target))
-                  (or (macher-agent-gptel--fsm-context target)
-                      (macher-agent--extract-fsm-context target)))
-                 ((and (recordp target) (fboundp 'gptel-fsm-info))
-                  (or (macher-agent-gptel--fsm-context target)
-                      (macher-agent--extract-fsm-context target)))
                  ((or (bufferp target) (stringp target))
                   (let ((buf (if (bufferp target) target (get-buffer target))))
                     (when (and buf (buffer-live-p buf))
-                      (or (let ((ctx (buffer-local-value 'macher-agent--persistent-context buf)))
-                            (when (macher-agent-valid-context-p ctx) ctx))
-                          (macher-agent-resolve-context buf)))))
+                      (let ((ctx (buffer-local-value 'macher-agent--persistent-context buf)))
+                        (when (macher-agent-valid-context-p ctx) ctx)))))
                  ((macher-agent--plist-p target)
-                  (or (plist-get target :macher-agent-context)
-                      (plist-get target :target-context)
-                      (plist-get target :parent-context)
-                      (plist-get target :context)
+                  (or (let ((c (plist-get target :macher-agent-context)))
+                        (when (macher-agent-valid-context-p c) c))
+                      (let ((c (plist-get target :target-context)))
+                        (when (macher-agent-valid-context-p c) c))
+                      (let ((c (plist-get target :parent-context)))
+                        (when (macher-agent-valid-context-p c) c))
+                      (let ((c (plist-get target :context)))
+                        (when (macher-agent-valid-context-p c) c))
                       (macher-agent-storage--extract-context target)
                       (when-let* ((buf (or (plist-get target :buffer) (plist-get target :target-buffer))))
                         (let ((live-buf (if (bufferp buf) buf (and (stringp buf) (get-buffer buf)))))
                           (when (and live-buf (buffer-live-p live-buf))
-                            (or (let ((ctx (buffer-local-value 'macher-agent--persistent-context live-buf)))
-                                  (when (macher-agent-valid-context-p ctx) ctx))
-                                (macher-agent-resolve-context live-buf)))))))))
+                            (let ((ctx (buffer-local-value 'macher-agent--persistent-context live-buf)))
+                              (when (macher-agent-valid-context-p ctx) ctx)))))))))
               (when (macher-agent-valid-context-p payload) payload)
               (when p-struct
                 (or (when-let* ((c (macher-agent-transit-payload-target-context p-struct)))
@@ -1274,14 +1252,12 @@ Return updated PAYLOAD or context."
                     (when-let* ((b (macher-agent-transit-payload-target-buffer p-struct)))
                       (let ((buf (if (bufferp b) b (and (stringp b) (get-buffer b)))))
                         (when (and buf (buffer-live-p buf))
-                          (or (let ((ctx (buffer-local-value 'macher-agent--persistent-context buf)))
-                                (when (macher-agent-valid-context-p ctx) ctx))
-                              (macher-agent-resolve-context buf)))))))
+                          (let ((ctx (buffer-local-value 'macher-agent--persistent-context buf)))
+                            (when (macher-agent-valid-context-p ctx) ctx)))))))
               (macher-agent-storage--extract-context payload)
               (when (and (bound-and-true-p macher-agent--persistent-context)
                          (macher-agent-valid-context-p macher-agent--persistent-context))
-                macher-agent--persistent-context)
-              (macher-agent-resolve-context)))
+                macher-agent--persistent-context)))
          (child-ctx (cond
                      (p-struct (macher-agent-transit-payload-child-context p-struct))
                      ((and (macher-agent-valid-context-p payload) (not (eq payload parent-ctx)))
@@ -1332,10 +1308,6 @@ Return updated PAYLOAD or context."
 
       (when (boundp 'macher-agent--persistent-context)
         (setq macher-agent--persistent-context parent-ctx))
-
-      (when (and explicit-target (fboundp 'gptel-fsm-p) (gptel-fsm-p explicit-target))
-        (when (fboundp 'macher-agent--inject-context-into-fsm-info)
-          (macher-agent--inject-context-into-fsm-info parent-ctx explicit-target)))
 
       (let* ((buf-candidates
               (cond

--- a/macher-agent.el
+++ b/macher-agent.el
@@ -1,7 +1,7 @@
 ;;; macher-agent.el --- Sandboxed, Language-Agnostic AI Workflows -*- lexical-binding: t; -*-
 
 ;; Author: Elijah Charles
-;; Version: 0.8.2.6
+;; Version: 0.8.2.7
 ;; Package-Requires: ((emacs "30.1") (gptel "0.9.9.6") (macher "0.5.2"))
 ;; Keywords: convenience, gptel, llm, macher
 ;; URL: https://github.com/elij/macher-agent

--- a/skills/scripts/delegate_tasks_to_subagents.el
+++ b/skills/scripts/delegate_tasks_to_subagents.el
@@ -35,17 +35,19 @@
                                       :presets (plist-get task :presets)
                                       :ephemeral (plist-get task :ephemeral)
                                       :suppress-patch t))))) 
-      (macher-agent-a2a-dispatch
-       dispatch-payloads
-       (lambda (results)
-         (let ((formatted-results
-                (cl-loop for res across results
-                         collect (format "=== Response from sub-agent ===\n%s\n"
-                                         (or (plist-get res :message)
-                                             (plist-get res :data)
-                                             (plist-get res :error)
-                                             res)))))
-           (funcall callback
-                    (format "All sub-agents completed:\n\n%s"
-                            (string-join formatted-results "\n")))))
-       context))))
+      (let ((saved-fsm (macher-agent-get-active-fsm)))
+        (macher-agent-a2a-dispatch
+         dispatch-payloads
+         (let ((fsm saved-fsm))
+           (lambda (results)
+             (let ((formatted-results
+                    (cl-loop for res across results
+                             collect (format "=== Response from sub-agent ===\n%s\n"
+                                             (or (plist-get res :message)
+                                                 (plist-get res :data)
+                                                 (plist-get res :error)
+                                                 res)))))
+               (funcall callback
+                        (format "All sub-agents completed:\n\n%s"
+                                (string-join formatted-results "\n"))))))
+         context)))))

--- a/skills/scripts/execute_subagents.el
+++ b/skills/scripts/execute_subagents.el
@@ -43,18 +43,20 @@ non-blocking manner using A2A payloads.  You must supply at least one preset."
                               :background t
                               :suppress-patch t))))))
 
-      (dolist (a2a-payload a2a-payloads)
-        (macher-agent-a2a-dispatch
-         (list a2a-payload)
-         (lambda (a2a-results)
-           (let* ((res (aref (if (vectorp a2a-results) a2a-results (vconcat a2a-results)) 0))
-                  (meta (macher-agent-transit-payload-metadata a2a-payload))
-                  (buf-name (plist-get meta :buffer_name))
-                  (is-error (eq (plist-get res :status) 'error)))
-             (if is-error
-                 (message "Background subagent %s task failed: %s" buf-name (plist-get res :error))
-               (message "Background subagent %s task execution completed successfully." buf-name))))
-         context))
+      (let ((current-fsm (macher-agent-get-active-fsm)))
+        (dolist (a2a-payload a2a-payloads)
+          (macher-agent-a2a-dispatch
+           (list a2a-payload)
+           (let ((saved-fsm current-fsm))
+             (lambda (a2a-results)
+               (let* ((res (aref (if (vectorp a2a-results) a2a-results (vconcat a2a-results)) 0))
+                      (meta (macher-agent-transit-payload-metadata a2a-payload))
+                      (buf-name (plist-get meta :buffer_name))
+                      (is-error (eq (plist-get res :status) 'error)))
+                 (if is-error
+                     (message "Background subagent %s task failed: %s" buf-name (plist-get res :error))
+                   (message "Background subagent %s task execution completed successfully." buf-name)))))
+           context)))
       
       (mapcar (lambda (p)
                 (let ((meta (macher-agent-transit-payload-metadata p)))

--- a/skills/scripts/ptc_execution.el
+++ b/skills/scripts/ptc_execution.el
@@ -15,8 +15,11 @@ and permitted tool primitives."))
   (lambda (payload context _root callback)
     (if-let*
         ((script (plist-get payload :script)))
-        (macher-agent-execute-ptc-script
-         script context
-         (lambda (res) (funcall callback res))
-         (lambda (err) (funcall callback err)))
+        (let ((target-buf (or (when (macher-agent-context-p context)
+                                (macher-agent-context-origin-buffer context))
+                              (current-buffer))))
+          (macher-agent-execute-ptc-script
+           script context target-buf
+           (lambda (res) (funcall callback res))
+           (lambda (err) (funcall callback err))))
       (error "No script provided for PTC execution"))))


### PR DESCRIPTION
- distribute context rather than fsm (as fsm only used to resolve context)